### PR TITLE
debugs Consume and Expel commands

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -100,5 +100,5 @@ public final class Constants {
     public static final double kDriveDeadband = 0.05;
 
     // Defines Intake constants
-    public static final double I_INTAKE_SPEED = 0.1;
+    public static final double I_INTAKE_SPEED = -0.1;
 }

--- a/src/main/java/frc/robot/commands/Intake/Consume.java
+++ b/src/main/java/frc/robot/commands/Intake/Consume.java
@@ -4,22 +4,17 @@
 
 package frc.robot.commands.Intake;
 
-
-import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
 
-import frc.robot.OI;
 import frc.robot.subsystems.Intake;
 import frc.robot.testingdashboard.TestingDashboard;
 
 public class Consume extends Command {
-  private static XboxController m_driverController;
   Intake m_intake;
 
-  /** Creates a new ArcadeDrive. */
+  /** Creates a new Consume. */
   public Consume() {
     m_intake = Intake.getInstance();
-    m_driverController = OI.getInstance().getDriverXboxController();
 
     addRequirements(m_intake);
   }

--- a/src/main/java/frc/robot/commands/Intake/Expel.java
+++ b/src/main/java/frc/robot/commands/Intake/Expel.java
@@ -5,22 +5,17 @@
 
 package frc.robot.commands.Intake;
 
-
-import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
 
-import frc.robot.OI;
 import frc.robot.subsystems.Intake;
 import frc.robot.testingdashboard.TestingDashboard;
 
 public class Expel extends Command {
-  private static XboxController m_driverController;
   Intake m_intake;
 
-  /** Creates a new ArcadeDrive. */
+  /** Creates a new Expel. */
   public Expel() {
     m_intake = Intake.getInstance();
-    m_driverController = OI.getInstance().getDriverXboxController();
 
     addRequirements(m_intake);
   }


### PR DESCRIPTION
This commit debugs the Consume and Expel commands, so the OI isn't called twice.
It also fixes the direction of the motors.