### PR TITLE
adds Field2d to the testing dashboard

### DIFF
--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -23,15 +23,18 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.util.WPIUtilJNI;
 import edu.wpi.first.wpilibj.ADIS16470_IMU;
 import edu.wpi.first.wpilibj.ADIS16470_IMU.IMUAxis;
+import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.DriverStation;
 import frc.robot.Constants;
 import frc.robot.RobotMap;
 import frc.robot.testingdashboard.SubsystemBase;
 import frc.robot.testingdashboard.TDNumber;
+import frc.robot.testingdashboard.TDSendable;
 import frc.robot.utils.SwerveUtils;
 
 public class Drive extends SubsystemBase {
   private static Drive m_drive;
+  private final Field2d m_field;
 
   // Create MAXSwerveModules
   private final MAXSwerveModule m_frontLeft = new MAXSwerveModule(
@@ -94,6 +97,9 @@ public class Drive extends SubsystemBase {
             m_rearLeft.getPosition(),
             m_rearRight.getPosition()
       }, new Pose2d());
+
+    m_field = new Field2d();
+    new TDSendable(this, "Field", "Position", m_field);
 
     TDxSpeedCommanded = new TDNumber(this, "Drive Input", "XInputSpeed");
     TDySpeedCommanded = new TDNumber(this, "Drive Input", "YInputSpeed");
@@ -259,8 +265,6 @@ public class Drive extends SubsystemBase {
       
       xSpeedCommanded = m_currentTranslationMag * Math.cos(m_currentTranslationDir);
       ySpeedCommanded = m_currentTranslationMag * Math.sin(m_currentTranslationDir);
-      TDxSpeedCommanded.set(xSpeedCommanded);
-      TDySpeedCommanded.set(ySpeedCommanded);
       m_currentRotation = m_rotLimiter.calculate(rot);
     } else {
       xSpeedCommanded = xSpeed;
@@ -305,6 +309,9 @@ public class Drive extends SubsystemBase {
   }
 
   public void drive(ChassisSpeeds speeds) {
+    TDxSpeedCommanded.set(speeds.vxMetersPerSecond);
+    TDySpeedCommanded.set(speeds.vyMetersPerSecond);
+    TDrotSpeedCommanded.set(speeds.omegaRadiansPerSecond);
     var swerveModuleStates = Constants.kDriveKinematics.toSwerveModuleStates(speeds);
     setModuleStates(swerveModuleStates);
   }
@@ -341,6 +348,9 @@ public class Drive extends SubsystemBase {
   }
 
   private void updateTD(){
+
+    m_field.setRobotPose(getPose());
+
     ChassisSpeeds measuredSpeeds = getMeasuredSpeeds();
     TDxSpeedMeasured.set(measuredSpeeds.vxMetersPerSecond);
     TDySpeedMeasured.set(measuredSpeeds.vyMetersPerSecond);

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -85,7 +85,9 @@ public class Shooter extends SubsystemBase {
 
   @Override
   public void periodic() {
-    if (Constants.kEnableShooterPIDTuning) {
+    if (Constants.kEnableShooterPIDTuning && 
+        m_LeftSparkPidController != null &&
+        m_RightSparkPidController != null) {
       m_LeftSparkPidController.setP(m_P.get());
       m_LeftSparkPidController.setI(m_I.get());
       m_LeftSparkPidController.setD(m_D.get());

--- a/src/main/java/frc/robot/testingdashboard/TDSendable.java
+++ b/src/main/java/frc/robot/testingdashboard/TDSendable.java
@@ -14,17 +14,11 @@ public class TDSendable implements TDValue {
     private String m_groupName;
     private String m_dataName;
     
-    public TDSendable(SubsystemBase subsystem, String groupName, String dataName) {
-        m_tabName = subsystem.getName();
-        m_groupName = groupName;
-        m_dataName = dataName;
-        TestingDashboard.getInstance().registerSendable(m_tabName, groupName, dataName, m_val);
-    }
-
     public TDSendable(SubsystemBase subsystem, String groupName, String dataName, Sendable val) {
         m_tabName = subsystem.getName();
         m_groupName = groupName;
         m_dataName = dataName;
+        m_val = val;
         TestingDashboard.getInstance().registerSendable(m_tabName, m_groupName, m_dataName, m_val);
     }
 

--- a/src/main/java/frc/robot/testingdashboard/TestingDashboard.java
+++ b/src/main/java/frc/robot/testingdashboard/TestingDashboard.java
@@ -116,7 +116,7 @@ public class TestingDashboard {
       System.out.println("WARNING: Subsystem for data does not exist!");
       return;
     }
-    System.out.println("Adding String data " + dataName);
+    System.out.println("Adding Sendable data " + dataName);
     if (tab.dataTable.addName(dataGrpName, dataName))
       tab.dataTable.addDefaultSendableValue(dataName, sendable);
   }


### PR DESCRIPTION
The Drive subsystem maintains a Field2d, drawing the robot pose on a dashboard element representing the field. This commit also fixes a typo in TDSendable and defends the Shooter when PIDs are enabled but the Shooter is not.