### PR TITLE
Field Utils, Rate Limiting, and Vision Enabling

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -147,7 +147,6 @@ public final class Constants {
     public static final double SHOOTER_INTAKING_SPEED_RPM = 0;
 
     // Vision Constants
-    public static final boolean kVisionEnabled = false;
     public static final String kCameraName = "Arducam_OV9281_USB_Camera";
     // Cam mounted facing forward, half a meter forward of center, half a meter up from center.
     public static final Transform3d kRobotToCam =

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -67,9 +67,7 @@ public class RobotContainer {
 
     m_shooter = Shooter.getInstance();
 
-    if(Constants.kVisionEnabled){
-      m_Vision = Vision.getInstance();
-    }
+    m_Vision = Vision.getInstance();
 
     NamedCommands.registerCommand("Consume", new Consume());
     NamedCommands.registerCommand("SpinUpShooter", new SpinUpShooter());

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -127,5 +127,5 @@ public class RobotMap {
 	public static int U_OPERATOR_XBOX_CONTROLLER = 1;
 
   //[V]ision
-  public static boolean V_ENABLED = true;
+  public static boolean V_ENABLED = false;
 }

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -95,8 +95,8 @@ public class RobotMap {
   public static double R_BASE_RADIUS_INCHES = 11.25 * Math.sqrt(2);
 
   // [B]arrel
-  public static int B_MOTOR = RoboRioMap.CAN_15;
   public static boolean B_ENABLED = true;
+  public static int B_MOTOR = RoboRioMap.CAN_15;
 
   //[D]rive
   public static int D_FRONT_LEFT_DRIVE = RoboRioMap.CAN_1;
@@ -125,4 +125,7 @@ public class RobotMap {
   //[U]ser Input
 	public static int U_DRIVER_XBOX_CONTROLLER = 0;
 	public static int U_OPERATOR_XBOX_CONTROLLER = 1;
+
+  //[V]ision
+  public static boolean V_ENABLED = true;
 }

--- a/src/main/java/frc/robot/commands/Drive/SwerveDrive.java
+++ b/src/main/java/frc/robot/commands/Drive/SwerveDrive.java
@@ -35,7 +35,7 @@ public class SwerveDrive extends Command {
       -MathUtil.applyDeadband(m_driverController.getLeftY(), Constants.kDriveDeadband),
       -MathUtil.applyDeadband(m_driverController.getLeftX(), Constants.kDriveDeadband),
       -MathUtil.applyDeadband(m_driverController.getRightX(), Constants.kDriveDeadband),
-      true, true);
+      true, false);
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/subsystems/Vision.java
+++ b/src/main/java/frc/robot/subsystems/Vision.java
@@ -13,6 +13,7 @@ import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 import org.photonvision.targeting.PhotonPipelineResult;
 
 import frc.robot.Constants;
+import frc.robot.RobotMap;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -34,20 +35,21 @@ public class Vision extends SubsystemBase {
   /** Creates a new Vision. */
   private Vision() {
     super("Vision");
-    m_camera = new PhotonCamera(Constants.kCameraName);
+    if(RobotMap.V_ENABLED){
+      m_camera = new PhotonCamera(Constants.kCameraName);
 
-    m_photonEstimator = new PhotonPoseEstimator(
-                          Constants.kTagLayout,
-                          PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
-                          m_camera,
-                          Constants.kRobotToCam);
-    
-    m_photonEstimator.setMultiTagFallbackStrategy(PoseStrategy.LOWEST_AMBIGUITY);
+      m_photonEstimator = new PhotonPoseEstimator(
+                            Constants.kTagLayout,
+                            PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
+                            m_camera,
+                            Constants.kRobotToCam);
+      
+      m_photonEstimator.setMultiTagFallbackStrategy(PoseStrategy.LOWEST_AMBIGUITY);
 
-    m_estX = new TDNumber(this, "Est Pose", "Est X");
-    m_estY = new TDNumber(this, "Est Pose", "Est Y");
-    m_estRot = new TDNumber(this, "Est Pose", "Est Rot");
-    
+      m_estX = new TDNumber(this, "Est Pose", "Est X");
+      m_estY = new TDNumber(this, "Est Pose", "Est Y");
+      m_estRot = new TDNumber(this, "Est Pose", "Est Rot");
+    }
   }
 
   public static Vision getInstance(){
@@ -59,57 +61,72 @@ public class Vision extends SubsystemBase {
 
   @Override
   public void periodic() {
-    Drive robotDrive = Drive.getInstance();
+    if(m_photonEstimator != null){
+      Drive robotDrive = Drive.getInstance();
 
-    var newest = getEstimatedGlobalPose();
-    newest.ifPresent(
-      est -> {
-        Pose2d estPose = est.estimatedPose.toPose2d();
-        var stdDevs = getEstimationStdDevs(estPose);
+      var newest = getEstimatedGlobalPose();
+      newest.ifPresent(
+        est -> {
+          Pose2d estPose = est.estimatedPose.toPose2d();
+          var stdDevs = getEstimationStdDevs(estPose);
 
-        robotDrive.addVisionMeasurement(estPose, m_lastEstTime, stdDevs);
+          robotDrive.addVisionMeasurement(estPose, m_lastEstTime, stdDevs);
 
-        m_estX.set(estPose.getX());
-        m_estY.set(estPose.getY());
-        m_estRot.set(estPose.getRotation().getDegrees());
-      }
-    );
+          m_estX.set(estPose.getX());
+          m_estY.set(estPose.getY());
+          m_estRot.set(estPose.getRotation().getDegrees());
+        }
+      );
+    }
     super.periodic();
   }
 
   public PhotonPipelineResult getLatestResult() {
-    return m_camera.getLatestResult();
+    if(m_camera != null){
+      return m_camera.getLatestResult();
+    } else {
+      return new PhotonPipelineResult();
+    }
   }
 
   public Optional<EstimatedRobotPose> getEstimatedGlobalPose() {
-    var visionEst = m_photonEstimator.update();
-    double latestTimestamp = m_camera.getLatestResult().getTimestampSeconds();
-    boolean newResult = Math.abs(latestTimestamp - m_lastEstTime) > 1e-5;
+    if(m_photonEstimator != null && m_camera != null){
+      var visionEst = m_photonEstimator.update();
+      double latestTimestamp = m_camera.getLatestResult().getTimestampSeconds();
+      boolean newResult = Math.abs(latestTimestamp - m_lastEstTime) > 1e-5;
 
-    if (newResult) m_lastEstTime = latestTimestamp;
-    return visionEst;
+      if (newResult) { m_lastEstTime = latestTimestamp; }
+      return visionEst;
+    } else {
+      return Optional.empty();
+    }
   }
 
   public Matrix<N3, N1> getEstimationStdDevs(Pose2d estimatedPose) {
         var estStdDevs = Constants.kSingleTagStdDevs;
-        var targets = getLatestResult().getTargets();
-        int numTags = targets.size();
-        double avgDist = 0;
-        for (var tgt : targets) {
-            var tagPose = m_photonEstimator.getFieldTags().getTagPose(tgt.getFiducialId());
-            if (tagPose.isEmpty()) continue;
-            numTags++;
-            avgDist +=
-                    tagPose.get().toPose2d().getTranslation().getDistance(estimatedPose.getTranslation());
+
+        if(m_photonEstimator != null){
+          var targets = getLatestResult().getTargets();
+          int numTags = targets.size();
+          double avgDist = 0;
+          for (var tgt : targets) {
+              var tagPose = m_photonEstimator.getFieldTags().getTagPose(tgt.getFiducialId());
+              if (tagPose.isEmpty()) continue;
+              numTags++;
+              avgDist +=
+                      tagPose.get().toPose2d().getTranslation().getDistance(estimatedPose.getTranslation());
+          }
+          if (numTags == 0) { return estStdDevs; }
+          avgDist /= numTags;
+          // Decrease std devs if multiple targets are visible
+          if (numTags > 1) { estStdDevs = Constants.kMultiTagStdDevs; }
+          // Increase std devs based on (average) distance
+          if (numTags == 1 && avgDist > 4) {
+              estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
+          } else {
+            estStdDevs = estStdDevs.times(1 + (avgDist * avgDist / 30));
+          }
         }
-        if (numTags == 0) return estStdDevs;
-        avgDist /= numTags;
-        // Decrease std devs if multiple targets are visible
-        if (numTags > 1) estStdDevs = Constants.kMultiTagStdDevs;
-        // Increase std devs based on (average) distance
-        if (numTags == 1 && avgDist > 4)
-            estStdDevs = VecBuilder.fill(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
-        else estStdDevs = estStdDevs.times(1 + (avgDist * avgDist / 30));
 
         return estStdDevs;
     }

--- a/src/main/java/frc/robot/utils/AllianceAprilTags.java
+++ b/src/main/java/frc/robot/utils/AllianceAprilTags.java
@@ -1,0 +1,37 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.utils;
+
+/** Add your docs here. */
+public class AllianceAprilTags {
+    public int speakerMiddle;
+    public int speakerSide;
+    public int amp;
+    public int sourceInner;
+    public int sourceOuter;
+    public int stageCenter;
+    public int stageDown;
+    public int stageUp;
+
+    public AllianceAprilTags(
+        int speakerMiddle,
+        int speakerSide,
+        int amp,
+        int sourceInner,
+        int sourceOuter,
+        int stageCenter,
+        int stageDown,
+        int stageUp
+    ){
+        this.speakerMiddle = speakerMiddle;
+        this.speakerSide = speakerSide;
+        this.amp = amp;
+        this.sourceInner = sourceInner;
+        this.sourceOuter = sourceOuter;
+        this.stageCenter = stageCenter;
+        this.stageDown = stageDown;
+        this.stageUp = stageUp;
+    }
+}

--- a/src/main/java/frc/robot/utils/FieldUtils.java
+++ b/src/main/java/frc/robot/utils/FieldUtils.java
@@ -1,0 +1,90 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.utils;
+
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.DriverStation;
+import frc.robot.Constants;
+
+public class FieldUtils{
+    private static FieldUtils m_fieldUtils;
+    private DriverStation.Alliance m_Alliance;
+    private AllianceAprilTags m_aprilTags;
+
+    public static final AllianceAprilTags RedTags = new AllianceAprilTags(4, 3, 5, 10, 9, 13, 11, 12);
+    public static final AllianceAprilTags BlueTags = new AllianceAprilTags(7, 8, 6, 1, 2, 14, 16, 15);
+
+    public static FieldUtils getInstance(){
+        if(m_fieldUtils == null){
+            m_fieldUtils = new FieldUtils();
+        }
+        return m_fieldUtils;
+    }
+
+    private FieldUtils(){
+        //Get alliance from driverstation
+        DriverStation.getAlliance().ifPresent(
+                alliance -> {
+                    m_Alliance = alliance;
+                    setAprilTags();
+                }
+        );
+    }
+
+    public AllianceAprilTags getAllianceAprilTags(){
+        if(m_aprilTags == null && m_Alliance != null)
+        {
+            setAprilTags();
+        }
+        return m_aprilTags;
+    }
+
+    public void setAlliance(DriverStation.Alliance alliance){
+        m_Alliance = alliance;
+    }
+
+    public void setAprilTags(){
+        if(m_Alliance == DriverStation.Alliance.Red){
+            m_aprilTags = RedTags;
+        }
+        else if(m_Alliance == DriverStation.Alliance.Blue){
+            m_aprilTags = BlueTags;
+        }
+        else{
+            System.out.println("Unrecognized Alliance Color");
+        }
+    }
+
+    public DriverStation.Alliance getAlliance(){
+        return m_Alliance;
+    }
+
+    public Pose3d getSpeakerPose(){
+        var aprilTags = getAllianceAprilTags();
+        if(aprilTags == null){
+            throw new RuntimeException("Attempted to get alliance specific info without a valid alliance");
+        }
+
+        return Constants.kTagLayout.getTagPose(aprilTags.speakerMiddle).get();
+    }
+
+    public Pose3d getAmpPose(){
+        var aprilTags = getAllianceAprilTags();
+        if(aprilTags == null){
+            throw new RuntimeException("Attempted to get alliance specific info without a valid alliance");
+        }
+
+        return Constants.kTagLayout.getTagPose(aprilTags.amp).get();
+    }
+
+    public Rotation2d getRotationOffset() {
+        if(m_Alliance == DriverStation.Alliance.Red){
+            return new Rotation2d(Math.PI);
+        } else {
+            return new Rotation2d();
+        }
+    }
+}


### PR DESCRIPTION
This merge adds the Field Utils singleton which contains methods for getting field locations and alliance specific information.
It also changes rate limiting in the drive subsystem to use acceleration and velocity limits instead of the slew rate limiter.
Finally it changes the way the Vision subsystem is enabled and disabled