### PR TITLE
cleans up TD parallel command group constructors.

### DIFF
--- a/src/main/java/frc/robot/testingdashboard/ParallelCommandGroup.java
+++ b/src/main/java/frc/robot/testingdashboard/ParallelCommandGroup.java
@@ -11,8 +11,9 @@ import com.pathplanner.lib.auto.NamedCommands;
 // https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
 public class ParallelCommandGroup extends edu.wpi.first.wpilibj2.command.ParallelCommandGroup {
 
-  public ParallelCommandGroup(SubsystemBase subsystem, String groupName, String name, boolean registerNamedCommand) {
-    super();
+  public ParallelCommandGroup(SubsystemBase subsystem, String groupName, String name, boolean registerNamedCommand, 
+                              edu.wpi.first.wpilibj2.command.Command... commands) {
+    super(commands);
     setName(name);
     TestingDashboard.getInstance().registerCommand(subsystem.getName(), groupName, this);
     if (registerNamedCommand) {
@@ -20,8 +21,9 @@ public class ParallelCommandGroup extends edu.wpi.first.wpilibj2.command.Paralle
     }
   }
 
-  public ParallelCommandGroup(SubsystemBase subsystem, String groupName, String name) {
-    this(subsystem, groupName, name, true);
+  public ParallelCommandGroup(SubsystemBase subsystem, String groupName, String name,
+                              edu.wpi.first.wpilibj2.command.Command... commands) {
+    this(subsystem, groupName, name, true, commands);
   }
 }
 

--- a/src/main/java/frc/robot/testingdashboard/ParallelDeadlineGroup.java
+++ b/src/main/java/frc/robot/testingdashboard/ParallelDeadlineGroup.java
@@ -15,8 +15,8 @@ public class ParallelDeadlineGroup extends edu.wpi.first.wpilibj2.command.Parall
                                String groupName,
                                String name,
                                boolean registerNamedCommand,
-                               Command deadline,
-                               Command... otherCommands) {
+                               edu.wpi.first.wpilibj2.command.Command deadline,
+                               edu.wpi.first.wpilibj2.command.Command... otherCommands) {
     super(deadline, otherCommands);
     setName(name);
     TestingDashboard.getInstance().registerCommand(subsystem.getName(), groupName, this);
@@ -25,7 +25,9 @@ public class ParallelDeadlineGroup extends edu.wpi.first.wpilibj2.command.Parall
     }
   }
 
-  public ParallelDeadlineGroup(SubsystemBase subsystem, String groupName, String name, Command deadline, Command...otherCommands) {
+  public ParallelDeadlineGroup(SubsystemBase subsystem, String groupName, String name, 
+                               edu.wpi.first.wpilibj2.command.Command deadline,
+                               edu.wpi.first.wpilibj2.command.Command... otherCommands) {
     this(subsystem, groupName, name, true, deadline, otherCommands);
   }
 }

--- a/src/main/java/frc/robot/testingdashboard/ParallelRaceGroup.java
+++ b/src/main/java/frc/robot/testingdashboard/ParallelRaceGroup.java
@@ -15,7 +15,7 @@ public class ParallelRaceGroup extends edu.wpi.first.wpilibj2.command.ParallelRa
                                String groupName,
                                String name,
                                boolean registerNamedCommand,
-                               Command... commands) {
+                               edu.wpi.first.wpilibj2.command.Command... commands) {
     super(commands);
     setName(name);
     TestingDashboard.getInstance().registerCommand(subsystem.getName(), groupName, this);
@@ -24,7 +24,8 @@ public class ParallelRaceGroup extends edu.wpi.first.wpilibj2.command.ParallelRa
     }
   }
 
-  public ParallelRaceGroup(SubsystemBase subsystem, String groupName, String name, Command... commands) {
+  public ParallelRaceGroup(SubsystemBase subsystem, String groupName, String name,
+                           edu.wpi.first.wpilibj2.command.Command... commands) {
     this(subsystem, groupName, name, true, commands);
   }
 }


### PR DESCRIPTION
ParallelCommandGroups (plain, deadline, race) now allow any wpilib Command as a constructor argument, not just a TD command. The plain ParallelCommandGroup now supports commands in the constructor, omitted inadvertently.