### PR TITLE
Drive updates and other changes

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -175,13 +175,13 @@ public final class Constants {
     public static final Matrix<N3, N1> kMultiTagStdDevs = VecBuilder.fill(0.5, 0.5, 1);
 
     //Autonomous driving constants
-    public static final double kMaxAccelerationMetersPerSecondSquared = 3;
+    public static final double kMaxAccelerationMetersPerSecondSquared = 10;
     public static final double kMaxAngularSpeedRadiansPerSecond = Math.PI;
-    public static final double kMaxAngularSpeedRadiansPerSecondSquared = Math.PI;
+    public static final double kMaxAngularSpeedRadiansPerSecondSquared = 4*Math.PI;
 
     public static final double kPXController = 1;
     public static final double kPYController = 1;
-    public static final double kPThetaController = 0.9;
+    public static final double kPThetaController = 5;
     public static final double kIThetaController = 0.1;
     public static final double kDThetaController = 0.05;
     public static final double kThetaTolerance = 0.1;//radians

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -6,10 +6,13 @@ package frc.robot;
 
 import frc.robot.commands.ExcreteNote;
 import frc.robot.commands.IngestNote;
+import frc.robot.commands.TestPoseMath;
 import frc.robot.commands.Barrel.SpinBackward;
 import frc.robot.commands.Barrel.SpinForward;
 import frc.robot.commands.Drive.SwerveDrive;
+import frc.robot.commands.Drive.TargetDrive;
 import frc.robot.commands.Drive.TurnToRotation;
+import frc.robot.commands.Drive.TurnToTarget;
 import frc.robot.commands.Intake.Consume;
 import frc.robot.commands.Intake.Expel;
 import frc.robot.commands.Lights.BlinkLights;
@@ -24,10 +27,13 @@ import frc.robot.subsystems.Intake;
 import frc.robot.subsystems.Lights;
 import frc.robot.subsystems.Shooter;
 import frc.robot.subsystems.Vision;
+import frc.robot.testingdashboard.TDNumber;
 import frc.robot.testingdashboard.TestingDashboard;
 
 import com.pathplanner.lib.auto.AutoBuilder;
 
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
@@ -98,6 +104,19 @@ public class RobotContainer {
     // Shooter commands
     new SpinUpShooter();
     new IntakeFromSource();
+
+    // TDNumber turnTestAngle = new TDNumber(Drive.getInstance(), "Test Inputs", "Turn Angle");
+    // new TurnToRotation(()->new Rotation2d(turnTestAngle.get()));
+    TDNumber testX = new TDNumber(Drive.getInstance(), "Test Inputs", "TargetPoseX");
+    TDNumber testY = new TDNumber(Drive.getInstance(), "Test Inputs", "TargetPoseY");
+    Pose2d targetPose = new Pose2d(testX.get(), testY.get(), new Rotation2d());
+    new TurnToTarget(targetPose);
+
+    new TargetDrive(()->{
+      return new Pose2d(testX.get(), testY.get(), new Rotation2d());
+    });
+
+    new TestPoseMath();
   }
 
   /**
@@ -121,6 +140,6 @@ public class RobotContainer {
    */
   public Command getAutonomousCommand() {
     // An example command will be run in autonomous
-    return AutoBuilder.buildAuto("autoCommand");
+    return AutoBuilder.buildAuto("3NotePaths");
   }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -6,7 +6,6 @@ package frc.robot;
 
 import frc.robot.commands.ExcreteNote;
 import frc.robot.commands.IngestNote;
-import frc.robot.commands.TestPoseMath;
 import frc.robot.commands.Barrel.SpinBackward;
 import frc.robot.commands.Barrel.SpinForward;
 import frc.robot.commands.Drive.SwerveDrive;
@@ -116,7 +115,6 @@ public class RobotContainer {
       return new Pose2d(testX.get(), testY.get(), new Rotation2d());
     });
 
-    new TestPoseMath();
   }
 
   /**

--- a/src/main/java/frc/robot/commands/Drive/SwerveDrive.java
+++ b/src/main/java/frc/robot/commands/Drive/SwerveDrive.java
@@ -4,22 +4,25 @@
 
 package frc.robot.commands.Drive;
 
+import java.util.function.Supplier;
+
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.XboxController;
 import frc.robot.Constants;
 import frc.robot.OI;
 import frc.robot.subsystems.Drive;
 import frc.robot.testingdashboard.Command;
+import frc.robot.utils.SwerveDriveInputs;
 
 public class SwerveDrive extends Command {
-  private static XboxController m_driverController;
+  private SwerveDriveInputs m_DriveInputs;
   Drive m_drive;
 
   /** Creates a new SwerveDrive. */
-  public SwerveDrive() {
+  public SwerveDrive(SwerveDriveInputs driveInputs) {
     super(Drive.getInstance(), "Basic", "SwerveDrive");
     m_drive = Drive.getInstance();
-    m_driverController = OI.getInstance().getDriverXboxController();
+    m_DriveInputs = driveInputs;
 
     addRequirements(m_drive);
   }
@@ -32,9 +35,9 @@ public class SwerveDrive extends Command {
   @Override
   public void execute() {
     m_drive.drive(
-      -MathUtil.applyDeadband(m_driverController.getLeftY(), Constants.kDriveDeadband),
-      -MathUtil.applyDeadband(m_driverController.getLeftX(), Constants.kDriveDeadband),
-      -MathUtil.applyDeadband(m_driverController.getRightX(), Constants.kDriveDeadband),
+      -MathUtil.applyDeadband(m_DriveInputs.getX(), Constants.kDriveDeadband),
+      -MathUtil.applyDeadband(m_DriveInputs.getY(), Constants.kDriveDeadband),
+      -MathUtil.applyDeadband(m_DriveInputs.getRotation(), Constants.kDriveDeadband),
       true, false);
   }
 

--- a/src/main/java/frc/robot/commands/Drive/TargetDrive.java
+++ b/src/main/java/frc/robot/commands/Drive/TargetDrive.java
@@ -1,0 +1,83 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.Drive;
+
+import java.util.function.Supplier;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.XboxController;
+import frc.robot.testingdashboard.Command;
+import frc.robot.testingdashboard.TDNumber;
+import frc.robot.utils.FieldUtils;
+import frc.robot.Constants;
+import frc.robot.OI;
+import frc.robot.subsystems.Drive;
+
+public class TargetDrive extends Command {
+    private XboxController m_driverController;
+    private Drive m_drive;
+    private Supplier<Pose2d> m_tgtSupplier;
+    private ProfiledPIDController m_thetaController;
+
+    TDNumber TDTargetAngle;
+
+  /** Creates a new TargetDrive. */
+  public TargetDrive(Supplier<Pose2d> targetSupplier) {
+    super(Drive.getInstance(), "", "TargetDrive");
+    m_driverController = OI.getInstance().getDriverXboxController();
+    m_drive = Drive.getInstance();
+    m_tgtSupplier = targetSupplier;
+
+      m_thetaController = new ProfiledPIDController(
+        Constants.kPThetaController, 0, Constants.kDThetaController, Constants.kThetaControllerConstraints);
+    m_thetaController.enableContinuousInput(-Math.PI, Math.PI);
+
+    m_thetaController.setTolerance(0.1);
+
+    TDTargetAngle = new TDNumber(m_drive, "Test Outputs", "OutputAngle");
+
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(m_drive);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    Pose2d targetPose = m_tgtSupplier.get();
+    Pose2d currentPose = m_drive.getPose();
+
+    Rotation2d targetRot = FieldUtils.getInstance().getAngleToPose(currentPose, targetPose);
+
+    TDTargetAngle.set(targetRot.getDegrees());
+
+    double rotation = m_thetaController.calculate(
+        MathUtil.angleModulus(currentPose.getRotation().getRadians()),
+        MathUtil.angleModulus(targetRot.getRadians()));
+
+    double xSpeed =  -MathUtil.applyDeadband(m_driverController.getLeftY(), Constants.kDriveDeadband) * Constants.kMaxSpeedMetersPerSecond;
+    double ySpeed =  -MathUtil.applyDeadband(m_driverController.getLeftX(), Constants.kDriveDeadband) * Constants.kMaxSpeedMetersPerSecond;
+
+    ChassisSpeeds outputSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotation, currentPose.getRotation());
+    m_drive.drive(outputSpeeds);
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/Drive/TargetDrive.java
+++ b/src/main/java/frc/robot/commands/Drive/TargetDrive.java
@@ -10,37 +10,49 @@ import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.XboxController;
 import frc.robot.testingdashboard.Command;
 import frc.robot.testingdashboard.TDNumber;
+import frc.robot.testingdashboard.TDSendable;
 import frc.robot.utils.FieldUtils;
+import frc.robot.utils.SwerveDriveInputs;
 import frc.robot.Constants;
 import frc.robot.OI;
 import frc.robot.subsystems.Drive;
 
 public class TargetDrive extends Command {
-    private XboxController m_driverController;
     private Drive m_drive;
+    private SwerveDriveInputs m_driveInputs;
     private Supplier<Pose2d> m_tgtSupplier;
     private ProfiledPIDController m_thetaController;
 
+    private final double periodTime = 0.002;
+
     TDNumber TDTargetAngle;
+    TDNumber TDRotationFeedForward;
+    TDSendable m_thetaControllerSendable;
 
   /** Creates a new TargetDrive. */
-  public TargetDrive(Supplier<Pose2d> targetSupplier) {
+  public TargetDrive(Supplier<Pose2d> targetSupplier, SwerveDriveInputs driveInputs) {
     super(Drive.getInstance(), "", "TargetDrive");
-    m_driverController = OI.getInstance().getDriverXboxController();
     m_drive = Drive.getInstance();
+    m_driveInputs = driveInputs;
     m_tgtSupplier = targetSupplier;
 
-      m_thetaController = new ProfiledPIDController(
+    m_thetaController = new ProfiledPIDController(
         Constants.kPThetaController, 0, Constants.kDThetaController, Constants.kThetaControllerConstraints);
     m_thetaController.enableContinuousInput(-Math.PI, Math.PI);
 
     m_thetaController.setTolerance(0.1);
 
+    m_thetaControllerSendable = new TDSendable(m_drive, "", "TargetDriveThetaController", m_thetaController);
+
     TDTargetAngle = new TDNumber(m_drive, "Test Outputs", "OutputAngle");
+    TDRotationFeedForward = new TDNumber(m_drive, "Test Outputs", "Rot FF");
 
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(m_drive);
@@ -55,19 +67,24 @@ public class TargetDrive extends Command {
   public void execute() {
     Pose2d targetPose = m_tgtSupplier.get();
     Pose2d currentPose = m_drive.getPose();
+    ChassisSpeeds fieldRelativeSpeeds = ChassisSpeeds.fromRobotRelativeSpeeds(m_drive.getMeasuredSpeeds(), currentPose.getRotation());
 
     Rotation2d targetRot = FieldUtils.getInstance().getAngleToPose(currentPose, targetPose);
 
     TDTargetAngle.set(targetRot.getDegrees());
 
     double rotation = m_thetaController.calculate(
-        MathUtil.angleModulus(currentPose.getRotation().getRadians()),
-        MathUtil.angleModulus(targetRot.getRadians()));
+            MathUtil.angleModulus(currentPose.getRotation().getRadians()),
+            MathUtil.angleModulus(targetRot.getRadians()));
+    double ff = calculateRotationFF(fieldRelativeSpeeds, currentPose, targetPose, targetRot);
+    TDRotationFeedForward.set(ff);
+    rotation += ff;
 
-    double xSpeed =  -MathUtil.applyDeadband(m_driverController.getLeftY(), Constants.kDriveDeadband) * Constants.kMaxSpeedMetersPerSecond;
-    double ySpeed =  -MathUtil.applyDeadband(m_driverController.getLeftX(), Constants.kDriveDeadband) * Constants.kMaxSpeedMetersPerSecond;
+    double xSpeed =  -MathUtil.applyDeadband(m_driveInputs.getX(), Constants.kDriveDeadband) * Constants.kMaxSpeedMetersPerSecond;
+    double ySpeed =  -MathUtil.applyDeadband(m_driveInputs.getY(), Constants.kDriveDeadband) * Constants.kMaxSpeedMetersPerSecond;
+    Rotation2d fieldRotationOffset = currentPose.getRotation().plus(FieldUtils.getInstance().getRotationOffset());
 
-    ChassisSpeeds outputSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotation, currentPose.getRotation());
+    ChassisSpeeds outputSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rotation, fieldRotationOffset);
     m_drive.drive(outputSpeeds);
   }
 
@@ -79,5 +96,16 @@ public class TargetDrive extends Command {
   @Override
   public boolean isFinished() {
     return false;
+  }
+
+  private double calculateRotationFF(ChassisSpeeds currentSpeeds, Pose2d currentPose, Pose2d targetPose, Rotation2d targetAngle) {
+    int inverter = currentPose.getX() > targetPose.getX()? -1 : 1;
+    Translation2d velocityTrans = new Translation2d(currentSpeeds.vxMetersPerSecond, currentSpeeds.vyMetersPerSecond);
+    Translation2d nextTrans = velocityTrans.times(periodTime);
+    Pose2d nextPose = currentPose.plus(new Transform2d(nextTrans, new Rotation2d()));
+    Rotation2d nextAngle = FieldUtils.getInstance().getAngleToPose(nextPose, targetPose);
+    Rotation2d dif = nextAngle.minus(targetAngle);
+    
+    return inverter * MathUtil.angleModulus(dif.getRadians())/periodTime;
   }
 }

--- a/src/main/java/frc/robot/commands/Drive/TurnToRotation.java
+++ b/src/main/java/frc/robot/commands/Drive/TurnToRotation.java
@@ -4,11 +4,13 @@
 
 package frc.robot.commands.Drive;
 
+import java.util.function.Supplier;
+
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Transform2d;
-import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import frc.robot.Constants;
 import frc.robot.subsystems.Drive;
 import frc.robot.testingdashboard.Command;
@@ -16,18 +18,21 @@ import frc.robot.testingdashboard.TDNumber;
 
 public class TurnToRotation extends Command {
   protected Drive m_drive;
-  protected Rotation2d m_targetRot;
+  protected Supplier<Rotation2d> m_targetSupplier;
+  private Rotation2d m_targetRot;
   private ProfiledPIDController m_thetaController;
+  
+  TDNumber m_TargetAngle;
 
-  public TurnToRotation(Rotation2d target) {
-    this(target, "Auto Commands", "TurnToTarget");
+  public TurnToRotation(Supplier<Rotation2d> target) {
+    this(target, "Auto Commands", "TurnToRotation");
   }
 
   //Used for subclasses so they can set they're own testing dashboard name
-  protected TurnToRotation(Rotation2d target, String groupName, String name){
+  protected TurnToRotation(Supplier<Rotation2d> targetSupplier, String groupName, String name){
     super(Drive.getInstance(), groupName, name);
     m_drive = Drive.getInstance();
-    m_targetRot = target;
+    m_targetSupplier = targetSupplier;
 
 
     m_thetaController = new ProfiledPIDController(
@@ -35,6 +40,8 @@ public class TurnToRotation extends Command {
     m_thetaController.enableContinuousInput(-Math.PI, Math.PI);
 
     m_thetaController.setTolerance(0.1);
+
+    m_TargetAngle = new TDNumber(m_drive, "Test Outputs", "OutputAngle");
  
     addRequirements(m_drive);
   }
@@ -42,7 +49,8 @@ public class TurnToRotation extends Command {
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-
+    m_targetRot = m_targetSupplier.get();
+    m_TargetAngle.set(m_targetRot.getDegrees());
   }
 
   // Called every time the scheduler runs while the command is scheduled.
@@ -50,8 +58,12 @@ public class TurnToRotation extends Command {
   public void execute() {
     Pose2d currentPose = m_drive.getPose();
 
-    double rotation = m_thetaController.calculate(currentPose.getRotation().getRadians(), m_targetRot.getRadians());
-    m_drive.drive(0,0, rotation, true, false);
+    double rotation = m_thetaController.calculate(
+        MathUtil.angleModulus(currentPose.getRotation().getRadians()),
+        MathUtil.angleModulus(m_targetRot.getRadians()));
+
+    ChassisSpeeds speeds = new ChassisSpeeds(0, 0, rotation);
+    m_drive.drive(speeds);
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/Drive/TurnToTarget.java
+++ b/src/main/java/frc/robot/commands/Drive/TurnToTarget.java
@@ -8,21 +8,28 @@ package frc.robot.commands.Drive;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
+import frc.robot.testingdashboard.TDNumber;
+import frc.robot.utils.FieldUtils;
 
 
 public class TurnToTarget extends TurnToRotation {
   private Pose2d m_target;
 
-  public TurnToTarget(Pose2d target) {
-    super(new Rotation2d(), "Auto Commands", "TurnToTarget");//Target Rotation will be reset on init
-    m_target = target;
-  }
+  TDNumber m_targetX;
+  TDNumber m_targetY;
 
-  // Called when the command is initially scheduled.
-  @Override
-  public void initialize() {
-    Pose2d currentPose = m_drive.getPose();
-    Transform2d trsfrm = m_target.minus(currentPose);
-    m_targetRot = new Rotation2d(trsfrm.getX(), trsfrm.getY());
+  public TurnToTarget(Pose2d target) {
+    super(()->new Rotation2d(), "Auto Commands", "TurnToTarget");
+    m_target = target;
+
+    m_targetX = new TDNumber(m_drive, "Test Inputs", "TargetPoseX");
+    m_targetY = new TDNumber(m_drive, "Test Inputs", "TargetPoseY");
+
+    m_targetSupplier = ()->{
+      Pose2d currentPose = m_drive.getPose();
+      m_targetX.set(m_target.getX());
+      m_targetY.set(m_target.getY());
+      return FieldUtils.getInstance().getAngleToPose(currentPose, m_target);
+    };
   }
 }

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -181,9 +181,10 @@ public class Drive extends SubsystemBase {
     Pose2d lastPose = getPose();
     if (m_driveTime != 0 && m_requestedSpeeds != null)
     {
-      double deltax = m_requestedSpeeds.vxMetersPerSecond * (now - m_driveTime);
-      double deltay = m_requestedSpeeds.vyMetersPerSecond * (now - m_driveTime);
-      Rotation2d rot = new Rotation2d(m_requestedSpeeds.omegaRadiansPerSecond * (now - m_driveTime));
+      ChassisSpeeds fieldRelativeSpeeds = ChassisSpeeds.fromRobotRelativeSpeeds(m_requestedSpeeds, lastPose.getRotation());
+      double deltax = fieldRelativeSpeeds.vxMetersPerSecond * (now - m_driveTime);
+      double deltay = fieldRelativeSpeeds.vyMetersPerSecond * (now - m_driveTime);
+      Rotation2d rot = new Rotation2d(fieldRelativeSpeeds.omegaRadiansPerSecond * (now - m_driveTime));
       Translation2d translation = new Translation2d(deltax, deltay);
       Pose2d newPose = new Pose2d(lastPose.getTranslation().plus(translation),
                                   lastPose.getRotation().plus(rot));

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -29,6 +29,7 @@ import edu.wpi.first.wpilibj.ADIS16470_IMU;
 import edu.wpi.first.wpilibj.ADIS16470_IMU.IMUAxis;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.Timer;
 import frc.robot.Constants;
 import frc.robot.RobotMap;
@@ -93,6 +94,7 @@ public class Drive extends SubsystemBase {
   TDNumber TDPoseAngle;
 
   ChassisSpeeds m_requestedSpeeds = new ChassisSpeeds();
+  ChassisSpeeds m_limitSpeeds = new ChassisSpeeds();
   double m_driveTime = 0;
 
   /** Creates a new Drive. */
@@ -179,9 +181,9 @@ public class Drive extends SubsystemBase {
     double now = Timer.getFPGATimestamp();
 
     Pose2d lastPose = getPose();
-    if (m_driveTime != 0 && m_requestedSpeeds != null)
+    if (m_driveTime != 0 && m_limitSpeeds != null)
     {
-      ChassisSpeeds fieldRelativeSpeeds = ChassisSpeeds.fromRobotRelativeSpeeds(m_requestedSpeeds, lastPose.getRotation());
+      ChassisSpeeds fieldRelativeSpeeds = ChassisSpeeds.fromRobotRelativeSpeeds(m_limitSpeeds, lastPose.getRotation());
       double deltax = fieldRelativeSpeeds.vxMetersPerSecond * (now - m_driveTime);
       double deltay = fieldRelativeSpeeds.vyMetersPerSecond * (now - m_driveTime);
       Rotation2d rot = new Rotation2d(fieldRelativeSpeeds.omegaRadiansPerSecond * (now - m_driveTime));
@@ -203,13 +205,17 @@ public class Drive extends SubsystemBase {
   }
 
   public ChassisSpeeds getMeasuredSpeeds(){
-    SwerveModuleState[] moduleStates = new SwerveModuleState[4];
-    moduleStates[0] = m_frontLeft.getState();
-    moduleStates[1] = m_frontRight.getState();
-    moduleStates[2] = m_rearLeft.getState();
-    moduleStates[3] = m_rearRight.getState();
+    if(RobotBase.isReal()){
+      SwerveModuleState[] moduleStates = new SwerveModuleState[4];
+      moduleStates[0] = m_frontLeft.getState();
+      moduleStates[1] = m_frontRight.getState();
+      moduleStates[2] = m_rearLeft.getState();
+      moduleStates[3] = m_rearRight.getState();
 
-    return Constants.kDriveKinematics.toChassisSpeeds(moduleStates);
+      return Constants.kDriveKinematics.toChassisSpeeds(moduleStates);
+    } else {
+      return m_limitSpeeds;
+    }
   }
 
   /**
@@ -343,10 +349,9 @@ public class Drive extends SubsystemBase {
     TDxSpeedCommanded.set(speeds.vxMetersPerSecond);
     TDySpeedCommanded.set(speeds.vyMetersPerSecond);
     TDrotSpeedCommanded.set(speeds.omegaRadiansPerSecond);
-    m_requestedSpeeds.vxMetersPerSecond = speeds.vxMetersPerSecond;
-    m_requestedSpeeds.vyMetersPerSecond = speeds.vyMetersPerSecond;
-    m_requestedSpeeds.omegaRadiansPerSecond = speeds.omegaRadiansPerSecond;
+    m_requestedSpeeds = speeds;
     ChassisSpeeds limitedSpeeds = limitRates(speeds);
+    m_limitSpeeds = limitedSpeeds;
     var swerveModuleStates = Constants.kDriveKinematics.toSwerveModuleStates(limitedSpeeds);
     setModuleStates(swerveModuleStates);
   }

--- a/src/main/java/frc/robot/utils/FieldUtils.java
+++ b/src/main/java/frc/robot/utils/FieldUtils.java
@@ -10,6 +10,7 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.DriverStation;
 import frc.robot.Constants;
 
@@ -70,9 +71,9 @@ public class FieldUtils{
     }
 
     public Rotation2d getAngleToPose(Pose2d currentPose, Pose2d targetPose) {
-        Pose2d curNoRot = new Pose2d(currentPose.getX(), currentPose.getY(), new Rotation2d());
-        Pose2d targetNoRot = new Pose2d(targetPose.getX(), targetPose.getY(), new Rotation2d());
-        Transform2d trsfrm = targetNoRot.minus(curNoRot);
-        return new Rotation2d(trsfrm.getX(), trsfrm.getY());
+        Translation2d curTrans = currentPose.getTranslation();
+        Translation2d targetTrans = targetPose.getTranslation();
+        Translation2d toTarget = targetTrans.minus(curTrans);
+        return toTarget.getAngle();
     }
 }

--- a/src/main/java/frc/robot/utils/FieldUtils.java
+++ b/src/main/java/frc/robot/utils/FieldUtils.java
@@ -4,6 +4,8 @@
 
 package frc.robot.utils;
 
+import java.util.Optional;
+
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.DriverStation;
@@ -11,8 +13,6 @@ import frc.robot.Constants;
 
 public class FieldUtils{
     private static FieldUtils m_fieldUtils;
-    private DriverStation.Alliance m_Alliance;
-    private AllianceAprilTags m_aprilTags;
 
     public static final AllianceAprilTags RedTags = new AllianceAprilTags(4, 3, 5, 10, 9, 13, 11, 12);
     public static final AllianceAprilTags BlueTags = new AllianceAprilTags(7, 8, 6, 1, 2, 14, 16, 15);
@@ -24,42 +24,19 @@ public class FieldUtils{
         return m_fieldUtils;
     }
 
-    private FieldUtils(){
-        //Get alliance from driverstation
-        DriverStation.getAlliance().ifPresent(
-                alliance -> {
-                    m_Alliance = alliance;
-                    setAprilTags();
-                }
-        );
-    }
+    private FieldUtils(){}
 
     public AllianceAprilTags getAllianceAprilTags(){
-        if(m_aprilTags == null && m_Alliance != null)
-        {
-            setAprilTags();
+        AllianceAprilTags tags = null;
+        Optional<DriverStation.Alliance> alliance = DriverStation.getAlliance();
+        if(alliance.isPresent()){
+            if(alliance.get() == DriverStation.Alliance.Red){
+                tags = RedTags;
+            } else if(alliance.get() == DriverStation.Alliance.Blue) {
+                tags = BlueTags;
+            }
         }
-        return m_aprilTags;
-    }
-
-    public void setAlliance(DriverStation.Alliance alliance){
-        m_Alliance = alliance;
-    }
-
-    public void setAprilTags(){
-        if(m_Alliance == DriverStation.Alliance.Red){
-            m_aprilTags = RedTags;
-        }
-        else if(m_Alliance == DriverStation.Alliance.Blue){
-            m_aprilTags = BlueTags;
-        }
-        else{
-            System.out.println("Unrecognized Alliance Color");
-        }
-    }
-
-    public DriverStation.Alliance getAlliance(){
-        return m_Alliance;
+        return tags;
     }
 
     public Pose3d getSpeakerPose(){
@@ -81,10 +58,12 @@ public class FieldUtils{
     }
 
     public Rotation2d getRotationOffset() {
-        if(m_Alliance == DriverStation.Alliance.Red){
-            return new Rotation2d(Math.PI);
-        } else {
-            return new Rotation2d();
+        Rotation2d offset = new Rotation2d();//returns no offset by default
+        Optional<DriverStation.Alliance> alliance = DriverStation.getAlliance();
+        if(alliance.isPresent() && 
+            alliance.get() == DriverStation.Alliance.Red){
+                offset = new Rotation2d(Math.PI);
         }
+        return offset;
     }
 }

--- a/src/main/java/frc/robot/utils/FieldUtils.java
+++ b/src/main/java/frc/robot/utils/FieldUtils.java
@@ -6,8 +6,10 @@ package frc.robot.utils;
 
 import java.util.Optional;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.wpilibj.DriverStation;
 import frc.robot.Constants;
 
@@ -65,5 +67,12 @@ public class FieldUtils{
                 offset = new Rotation2d(Math.PI);
         }
         return offset;
+    }
+
+    public Rotation2d getAngleToPose(Pose2d currentPose, Pose2d targetPose) {
+        Pose2d curNoRot = new Pose2d(currentPose.getX(), currentPose.getY(), new Rotation2d());
+        Pose2d targetNoRot = new Pose2d(targetPose.getX(), targetPose.getY(), new Rotation2d());
+        Transform2d trsfrm = targetNoRot.minus(curNoRot);
+        return new Rotation2d(trsfrm.getX(), trsfrm.getY());
     }
 }

--- a/src/main/java/frc/robot/utils/FieldUtils.java
+++ b/src/main/java/frc/robot/utils/FieldUtils.java
@@ -30,7 +30,7 @@ public class FieldUtils{
     private FieldUtils(){}
 
     public AllianceAprilTags getAllianceAprilTags(){
-        AllianceAprilTags tags = null;
+        AllianceAprilTags tags = BlueTags;
         Optional<DriverStation.Alliance> alliance = DriverStation.getAlliance();
         if(alliance.isPresent()){
             if(alliance.get() == DriverStation.Alliance.Red){
@@ -45,7 +45,7 @@ public class FieldUtils{
     public Pose3d getSpeakerPose(){
         var aprilTags = getAllianceAprilTags();
         if(aprilTags == null){
-            throw new RuntimeException("Attempted to get alliance specific info without a valid alliance");
+            aprilTags = BlueTags;
         }
 
         return Constants.kTagLayout.getTagPose(aprilTags.speakerMiddle).get();
@@ -54,7 +54,7 @@ public class FieldUtils{
     public Pose3d getAmpPose(){
         var aprilTags = getAllianceAprilTags();
         if(aprilTags == null){
-            throw new RuntimeException("Attempted to get alliance specific info without a valid alliance");
+            aprilTags = BlueTags;
         }
 
         return Constants.kTagLayout.getTagPose(aprilTags.amp).get();

--- a/src/main/java/frc/robot/utils/NoteProximitySensor.java
+++ b/src/main/java/frc/robot/utils/NoteProximitySensor.java
@@ -1,0 +1,72 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.utils;
+
+import edu.wpi.first.wpilibj.DigitalInput;
+
+/** Add your docs here. */
+public class NoteProximitySensor {
+    private enum State {
+        c_State_No_Note,
+        c_State_First_Leg,
+        c_State_Middle_Hole,
+        c_State_Second_Leg
+    };
+    private DigitalInput m_sensorDIO;
+    private State m_state;
+
+    public NoteProximitySensor(int dioPort) {
+        m_sensorDIO = new DigitalInput(dioPort);
+        m_state = State.c_State_No_Note;
+    }
+
+    public void update(){
+        boolean val = m_sensorDIO.get();
+        State nextState = State.c_State_No_Note;
+
+        switch (m_state) {
+            case c_State_No_Note:
+                if(val){
+                    nextState = State.c_State_First_Leg;
+                } else {
+                    nextState = State.c_State_No_Note;
+                }
+                break;
+
+            case c_State_First_Leg:
+                if(val){
+                    nextState = State.c_State_First_Leg;
+                } else {
+                    nextState = State.c_State_Middle_Hole;
+                }
+                break;
+
+            case c_State_Middle_Hole:
+                if(val){
+                    nextState = State.c_State_Second_Leg;
+                } else {
+                    nextState = State.c_State_Middle_Hole;
+                }
+
+            case c_State_Second_Leg:
+                if(val){
+                    nextState = State.c_State_Second_Leg;
+                } else {
+                    nextState = State.c_State_No_Note;
+                }
+
+            default:
+                System.out.println("Note Proximity Sensor has invalid state");
+                nextState = State.c_State_No_Note;
+                break;
+        }
+
+        m_state = nextState;
+    }
+
+    public boolean hasNote() {
+        return m_state != State.c_State_No_Note;
+    }
+}

--- a/src/main/java/frc/robot/utils/SwerveDriveInputs.java
+++ b/src/main/java/frc/robot/utils/SwerveDriveInputs.java
@@ -1,0 +1,32 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.utils;
+
+import java.util.function.Supplier;
+
+/** Add your docs here. */
+public class SwerveDriveInputs {
+    Supplier<Double> m_xSupplier;
+    Supplier<Double> m_ySupplier;
+    Supplier<Double> m_rotSupplier;
+
+    public SwerveDriveInputs(Supplier<Double> xSupplier, Supplier<Double> ySupplier, Supplier<Double> rotationSupplier){
+        m_xSupplier = xSupplier;
+        m_ySupplier = ySupplier;
+        m_rotSupplier = rotationSupplier;
+    }
+
+    public double getX(){
+        return m_xSupplier.get();
+    }
+
+    public double getY(){
+        return m_ySupplier.get();
+    }
+
+    public double getRotation(){
+        return m_rotSupplier.get();
+    }
+}


### PR DESCRIPTION
This merge makes several updates to the code, mainly in the drive subsystem and command, but also adds changes in several other areas.

Drive changes
- Adds TargetDrive command which rotates the robot to aim at a particular spot on the field while translating
- Adds TurnToRotation & TurnToTarget commands
- Changes the input flow for driving with the SwerveDriveInputs class
- Changes acceleration limits to make drive more responsive

FieldUtils
- No longer caches alliance, so alliance can be changed on the fly
- Adds getAngleToPose method which returns the Rotation2d between 2 poses
- Removes RunTimeExceptions by defaulting to Blue Alliance

Simulation
- Fixes chassis speeds update to convert from robot relative
- Changes inputs drive inputs for sim so WASD drive actually makes sense
- Changes drive to update with limited speeds to better represent robot behavior

Adds new NoteProximitySensor class