### PR TITLE
adds untested BarrelPivot movement command

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -29,9 +29,11 @@ import edu.wpi.first.math.util.Units;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
+    public static final double DEGREES_PER_REVOLUTION = 360;
+
     // Defines AmpAddOn constants
     public static final double AMP_SPEED = 0.2;
-
+    
     // Defines Barrel constants
     public static final boolean kEnableBarrelPIDTuning = false;
     public static final double kBarrelP = 0;
@@ -43,9 +45,14 @@ public final class Constants {
 
     // Defines Barrel Pivot constants
     public static final boolean kEnableBarrelPivotPIDTuning = false;
-    public static final double kBarrelPivotP = 0;
+    public static final double kBarrelPivotP = 0.01;
     public static final double kBarrelPivotI = 0;
     public static final double kBarrelPivotD = 0;
+
+    public static final double kBPEncoderPositionFactorDegrees = DEGREES_PER_REVOLUTION;
+
+    public static final double BP_ANGLE_INCREMENT_DEGREES = 0.2;
+    public static final double kBPDeadband = 0.05;
 
     // Defines Drive constants
     public static final double kMaxSpeedMetersPerSecond = 4.8;

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -23,6 +23,7 @@ import frc.robot.commands.ExcreteNote;
 import frc.robot.commands.IngestNote;
 import frc.robot.commands.Shoot;
 import frc.robot.commands.ShooterIngestNote;
+import frc.robot.commands.BarrelPivot.SetZeroAsCurrentPosition;
 import frc.robot.commands.Drive.TurnToTarget;
 
 /**
@@ -60,6 +61,7 @@ public class OI {
     new JoystickButton(m_DriverXboxController, Button.kY.value).whileTrue(new ShooterIngestNote());
 
     new JoystickButton(m_DriverXboxController, Button.kBack.value).onTrue(new InstantCommand(()->Drive.getInstance().zeroHeading()));
+    new JoystickButton(m_OperatorXboxController, Button.kBack.value).whileTrue(new SetZeroAsCurrentPosition());
     // new JoystickButton(m_DriverXboxController, Button.kRightBumper.value).toggleOnTrue(new MakeRainbow());
     // new JoystickButton(m_DriverXboxController, Button.kLeftBumper.value).toggleOnTrue(new DisableLights());
     // new JoystickButton(m_DriverXboxController, Button.kX.value).toggleOnTrue(new BlinkLights());

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -6,6 +6,8 @@ package frc.robot;
 
 import frc.robot.commands.ExcreteNote;
 import frc.robot.commands.IngestNote;
+import frc.robot.commands.Shoot;
+import frc.robot.commands.ShooterIngestNote;
 import frc.robot.commands.Barrel.SpinBackward;
 import frc.robot.commands.Barrel.SpinForward;
 import frc.robot.commands.Drive.SwerveDrive;
@@ -19,8 +21,9 @@ import frc.robot.commands.Lights.DisableLights;
 import frc.robot.commands.Lights.EnableLights;
 import frc.robot.commands.Lights.MakeRainbow;
 import frc.robot.commands.Lights.MoveLights;
-import frc.robot.commands.Shooter.IntakeFromSource;
+import frc.robot.commands.Shooter.IntakeFromShooter;
 import frc.robot.commands.Shooter.SpinUpShooter;
+import frc.robot.subsystems.BarrelPivot;
 import frc.robot.subsystems.Drive;
 import frc.robot.subsystems.Intake;
 import frc.robot.subsystems.Lights;
@@ -59,6 +62,7 @@ public class RobotContainer {
   private final Intake m_intake;
   private final Lights m_lights;
   private final Shooter m_shooter;
+  private final BarrelPivot m_barrelPivot;
 
   private SwerveDriveInputs m_driveInputs;
 
@@ -89,6 +93,8 @@ public class RobotContainer {
     m_robotDrive = Drive.getInstance();
     m_robotDrive.setDefaultCommand(new SwerveDrive(m_driveInputs));
 
+    m_barrelPivot = BarrelPivot.getInstance();
+
     m_intake = Intake.getInstance();
 
     m_lights = Lights.getInstance();
@@ -109,7 +115,7 @@ public class RobotContainer {
     // Barrel commands
     new SpinForward();
     new SpinBackward();
-
+    
     // Intake commands
     new Consume();
     new Expel();
@@ -122,8 +128,14 @@ public class RobotContainer {
     new MoveLights();
 
     // Shooter commands
+    new IntakeFromShooter();
     new SpinUpShooter();
-    new IntakeFromSource();
+
+    new Shoot();
+    new ShooterIngestNote();
+
+    new IngestNote();
+    new ExcreteNote();
 
     // TDNumber turnTestAngle = new TDNumber(Drive.getInstance(), "Test Inputs", "Turn Angle");
     // new TurnToRotation(()->new Rotation2d(turnTestAngle.get()));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -10,6 +10,8 @@ import frc.robot.commands.Shoot;
 import frc.robot.commands.ShooterIngestNote;
 import frc.robot.commands.Barrel.SpinBackward;
 import frc.robot.commands.Barrel.SpinForward;
+import frc.robot.commands.BarrelPivot.PivotRelativeAngleControl;
+import frc.robot.commands.BarrelPivot.SetZeroAsCurrentPosition;
 import frc.robot.commands.Drive.SwerveDrive;
 import frc.robot.commands.Drive.TargetDrive;
 import frc.robot.commands.Drive.TurnToRotation;
@@ -94,6 +96,9 @@ public class RobotContainer {
     m_robotDrive.setDefaultCommand(new SwerveDrive(m_driveInputs));
 
     m_barrelPivot = BarrelPivot.getInstance();
+    if (RobotMap.BP_ENABLED) {
+      m_barrelPivot.setDefaultCommand(new PivotRelativeAngleControl());
+    }
 
     m_intake = Intake.getInstance();
 
@@ -115,7 +120,10 @@ public class RobotContainer {
     // Barrel commands
     new SpinForward();
     new SpinBackward();
-    
+
+    // BarrelPivot commands
+    new SetZeroAsCurrentPosition();
+
     // Intake commands
     new Consume();
     new Expel();

--- a/src/main/java/frc/robot/commands/BarrelPivot/PivotRelativeAngleControl.java
+++ b/src/main/java/frc/robot/commands/BarrelPivot/PivotRelativeAngleControl.java
@@ -1,0 +1,53 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.BarrelPivot;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.XboxController;
+import frc.robot.Constants;
+import frc.robot.OI;
+import frc.robot.subsystems.BarrelPivot;
+import frc.robot.testingdashboard.Command;;
+
+public class PivotRelativeAngleControl extends Command {
+  BarrelPivot m_barrelPivot;
+  XboxController m_operatorController;
+
+  /** Creates a new PivotRelativeAngleControl. */
+  public PivotRelativeAngleControl() {
+    super(BarrelPivot.getInstance(), "Basic", "PivotRelativeAngleControl");
+    m_barrelPivot = BarrelPivot.getInstance();
+    m_operatorController = OI.getInstance().getOperatorXboxController();
+    
+    addRequirements(m_barrelPivot);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    m_barrelPivot.setTargetAngle(0);
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    double angle = m_barrelPivot.getTargetAngle();
+    double input = MathUtil.applyDeadband(m_operatorController.getLeftY(), Constants.kBPDeadband);
+
+    angle += input * Constants.BP_ANGLE_INCREMENT_DEGREES;
+
+    m_barrelPivot.setTargetAngle(angle);
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/BarrelPivot/SetZeroAsCurrentPosition.java
+++ b/src/main/java/frc/robot/commands/BarrelPivot/SetZeroAsCurrentPosition.java
@@ -1,0 +1,41 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.BarrelPivot;
+
+import frc.robot.testingdashboard.Command;
+import frc.robot.subsystems.Barrel;
+import frc.robot.subsystems.BarrelPivot;
+
+public class SetZeroAsCurrentPosition extends Command {
+  BarrelPivot m_barrelPivot;
+
+  /** Creates a new setZeroAsCurrentPosition. */
+  public SetZeroAsCurrentPosition() {
+    super(Barrel.getInstance(), "Basic", "SetZeroAsCurrentPosition");
+    m_barrelPivot = BarrelPivot.getInstance();
+    
+    addRequirements(m_barrelPivot);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    m_barrelPivot.setZeroAsCurrentPosition();
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {}
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return true;
+  }
+}

--- a/src/main/java/frc/robot/commands/Shooter/IntakeFromShooter.java
+++ b/src/main/java/frc/robot/commands/Shooter/IntakeFromShooter.java
@@ -9,7 +9,7 @@ import frc.robot.subsystems.Shooter;
 import frc.robot.testingdashboard.Command;
 import frc.robot.testingdashboard.TDNumber;
 
-public class IntakeFromSource extends Command {
+public class IntakeFromShooter extends Command {
   Shooter m_shooter;
 
   TDNumber m_RPM;
@@ -17,9 +17,9 @@ public class IntakeFromSource extends Command {
 
   TDNumber m_shooterSpeed;
 
-  /** Creates a new IntakeFromSource. */
-  public IntakeFromSource() {
-    super(Shooter.getInstance(), "Basic", "IntakeFromSource");
+  /** Creates a new IntakeFromShooter. */
+  public IntakeFromShooter() {
+    super(Shooter.getInstance(), "Basic", "IntakeFromShooter");
     m_shooter = Shooter.getInstance();
 
     m_RPM = new TDNumber(m_shooter, "Intaking Speed (RPM)", "RPM", Constants.SHOOTER_INTAKING_SPEED_RPM);

--- a/src/main/java/frc/robot/commands/ShooterIngestNote.java
+++ b/src/main/java/frc/robot/commands/ShooterIngestNote.java
@@ -6,7 +6,7 @@ package frc.robot.commands;
 
 import frc.robot.testingdashboard.ParallelCommandGroup;
 import frc.robot.commands.Barrel.SpinBackward;
-import frc.robot.commands.Shooter.IntakeFromSource;
+import frc.robot.commands.Shooter.IntakeFromShooter;
 import frc.robot.subsystems.Shooter;
 
 // NOTE:  Consider using this command inline, rather than writing a subclass.  For more
@@ -18,6 +18,6 @@ public class ShooterIngestNote extends ParallelCommandGroup {
     super(Shooter.getInstance(), "ParallelCommands", "ShooterIngestNote");
     // Add your commands in the addCommands() call, e.g.
     // addCommands(new FooCommand(), new BarCommand());
-    addCommands(new IntakeFromSource(), new SpinBackward());
+    addCommands(new IntakeFromShooter(), new SpinBackward());
   }
 }

--- a/src/main/java/frc/robot/subsystems/BarrelPivot.java
+++ b/src/main/java/frc/robot/subsystems/BarrelPivot.java
@@ -5,8 +5,13 @@
 package frc.robot.subsystems;
 
 import com.revrobotics.CANSparkLowLevel.MotorType;
+import com.revrobotics.SparkAbsoluteEncoder.Type;
+
+import com.revrobotics.AbsoluteEncoder;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.SparkPIDController;
+import com.revrobotics.CANSparkBase.ControlType;
+import com.revrobotics.CANSparkBase.IdleMode;
 
 import frc.robot.Constants;
 import frc.robot.RobotMap;
@@ -16,13 +21,18 @@ import frc.robot.testingdashboard.TDNumber;
 public class BarrelPivot extends SubsystemBase {
   private static BarrelPivot m_barrelPivot;
 
+  double m_targetAngle;
+
   TDNumber m_P;
   TDNumber m_I;
   TDNumber m_D;
+  TDNumber m_encoderValueRotations;
+  TDNumber m_encoderValueAngleDegrees;
   
   CANSparkMax m_BPLeftSparkMax;
   CANSparkMax m_BPRightSparkMax;
   SparkPIDController m_SparkPIDController;
+  AbsoluteEncoder m_absoluteEncoder;
 
   /** Creates a new BarrelPivot. */
   private BarrelPivot() {
@@ -35,8 +45,10 @@ public class BarrelPivot extends SubsystemBase {
       m_BPLeftSparkMax.restoreFactoryDefaults();
       m_BPRightSparkMax.restoreFactoryDefaults();
 
+      m_BPLeftSparkMax.setIdleMode(IdleMode.kBrake);
+      m_BPRightSparkMax.setIdleMode(IdleMode.kBrake);
+
       m_BPLeftSparkMax.setInverted(false);
-      
       // Motors are set opposite of each other, but they want to spin in the same direction
       m_BPRightSparkMax.follow(m_BPLeftSparkMax, true);
 
@@ -49,6 +61,16 @@ public class BarrelPivot extends SubsystemBase {
       m_SparkPIDController.setP(m_P.get());
       m_SparkPIDController.setI(m_I.get());
       m_SparkPIDController.setD(m_D.get());
+
+      m_absoluteEncoder = m_BPLeftSparkMax.getAbsoluteEncoder(Type.kDutyCycle);
+      m_SparkPIDController.setFeedbackDevice(m_absoluteEncoder);
+
+      m_absoluteEncoder.setInverted(false);
+      m_absoluteEncoder.setPositionConversionFactor(Constants.kBPEncoderPositionFactorDegrees);
+      m_targetAngle = getAngle();
+
+      m_encoderValueRotations = new TDNumber(this, "Encoder Values", "Rotations", getAngle() / Constants.kBPEncoderPositionFactorDegrees);
+      m_encoderValueAngleDegrees = new TDNumber(this, "Encoder Values", "Angle (degrees)", getAngle());
     }
   }
 
@@ -58,16 +80,37 @@ public class BarrelPivot extends SubsystemBase {
     }
     return m_barrelPivot;
   }
-  
+
+  public double getAngle() {
+    return m_absoluteEncoder.getPosition();
+  }
+
+  public void setTargetAngle(double angle) {
+    m_targetAngle = angle;
+    m_SparkPIDController.setReference(m_targetAngle, ControlType.kVelocity);
+  }
+
+  public double getTargetAngle() {
+    return m_targetAngle;
+  }
+
+  public void setZeroAsCurrentPosition() {
+    m_absoluteEncoder.setZeroOffset(getAngle());
+    m_targetAngle = 0;
+  }
+
   @Override
   public void periodic() {
-    if (Constants.kEnableBarrelPivotPIDTuning && 
-        m_SparkPIDController != null) {
-      m_SparkPIDController.setP(m_P.get());
-      m_SparkPIDController.setI(m_I.get());
-      m_SparkPIDController.setD(m_D.get());
-    }
+    if (RobotMap.BP_ENABLED) {
+      if (Constants.kEnableBarrelPivotPIDTuning) {
+        m_SparkPIDController.setP(m_P.get());
+        m_SparkPIDController.setI(m_I.get());
+        m_SparkPIDController.setD(m_D.get());
+      }
 
+      m_encoderValueRotations.set(getAngle() / Constants.kBPEncoderPositionFactorDegrees);
+      m_encoderValueAngleDegrees.set(getAngle());
+    }
     super.periodic();
   }
 }


### PR DESCRIPTION
This commit adds untested BarrelPivot code which uses the absolute
encoder to move the arm based on joystick inputs.

SetZeroAsCurrentPosition will be helpful for testing, but shouldn't be
needed once we determine the permanent "zero".

Inversion of the motor/absolute encoder (so that "up" is upward
rotation and "down" is downward rotation) is currently unknown.