### PR TITLE
adds PID and AmpPivotRelativeAngleControl to AmpAddOn

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -36,7 +36,17 @@ public final class Constants {
 
     // Defines AmpAddOn constants
     public static final double AMP_SPEED = 0.2;
+
+    public static final boolean kEnableAmpAddOnPIDTuning = false;
+    public static final double kAmpPivotP = 0.01;
+    public static final double kAmpPivotI = 0;
+    public static final double kAmpPivotD = 0;
+
+    public static final double kAEncoderPositionFactorDegrees = DEGREES_PER_REVOLUTION;
     
+    public static final double A_ANGLE_INCREMENT_DEGREES = 0.2;
+    public static final double kADeadband = 0.05;
+
     // Defines Barrel constants
     public static final boolean kEnableBarrelPIDTuning = false;
     public static final double kBarrelP = 0;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -36,8 +36,12 @@ public final class Constants {
 
     // Defines AmpAddOn constants
     public static final double AMP_SPEED = 0.2;
+    public static final double AMP_SPEED_RPM = 0;
 
     public static final boolean kEnableAmpAddOnPIDTuning = false;
+    public static final double kAmpP = 0;
+    public static final double kAmpI = 0;
+    public static final double kAmpD = 0;
     public static final double kAmpPivotP = 0.01;
     public static final double kAmpPivotI = 0;
     public static final double kAmpPivotD = 0;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -9,6 +9,9 @@ import frc.robot.commands.IngestNote;
 import frc.robot.commands.Shoot;
 import frc.robot.commands.ShooterIngestNote;
 import frc.robot.commands.AmpAddOn.AmpPivotRelativeAngleControl;
+import frc.robot.commands.AmpAddOn.AmpSetZeroAsCurrentPosition;
+import frc.robot.commands.AmpAddOn.ScoreAmp;
+import frc.robot.commands.AmpAddOn.UNScoreAmp;
 import frc.robot.commands.Barrel.SpinBackward;
 import frc.robot.commands.Barrel.SpinForward;
 import frc.robot.commands.BarrelPivot.PivotRelativeAngleControl;
@@ -133,6 +136,11 @@ public class RobotContainer {
   }
 
   private void registerCommands() {
+    // Amp Add-On commands
+    new ScoreAmp();
+    new UNScoreAmp();
+    new AmpSetZeroAsCurrentPosition();
+
     // Barrel commands
     new SpinForward();
     new SpinBackward();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -8,6 +8,7 @@ import frc.robot.commands.ExcreteNote;
 import frc.robot.commands.IngestNote;
 import frc.robot.commands.Shoot;
 import frc.robot.commands.ShooterIngestNote;
+import frc.robot.commands.AmpAddOn.AmpPivotRelativeAngleControl;
 import frc.robot.commands.Barrel.SpinBackward;
 import frc.robot.commands.Barrel.SpinForward;
 import frc.robot.commands.BarrelPivot.PivotRelativeAngleControl;
@@ -26,6 +27,7 @@ import frc.robot.commands.Lights.MakeRainbow;
 import frc.robot.commands.Lights.MoveLights;
 import frc.robot.commands.Shooter.IntakeFromShooter;
 import frc.robot.commands.Shooter.SpinUpShooter;
+import frc.robot.subsystems.AmpAddOn;
 import frc.robot.subsystems.BarrelPivot;
 import frc.robot.subsystems.Drive;
 import frc.robot.subsystems.Intake;
@@ -68,6 +70,7 @@ public class RobotContainer {
   private final Lights m_lights;
   private final Shooter m_shooter;
   private final BarrelPivot m_barrelPivot;
+  private final AmpAddOn m_ampAddOn;
   private final SendableChooser<Command> m_autoChooser;
 
   private SwerveDriveInputs m_driveInputs;
@@ -98,6 +101,11 @@ public class RobotContainer {
     // Robot subsystems initialized and configured here
     m_robotDrive = Drive.getInstance();
     m_robotDrive.setDefaultCommand(new SwerveDrive(m_driveInputs));
+
+    m_ampAddOn = AmpAddOn.getInstance();
+    if (RobotMap.A_ENABLED) {
+      m_ampAddOn.setDefaultCommand(new AmpPivotRelativeAngleControl());
+    }
 
     m_barrelPivot = BarrelPivot.getInstance();
     if (RobotMap.BP_ENABLED) {

--- a/src/main/java/frc/robot/commands/AmpAddOn/AmpPivotRelativeAngleControl.java
+++ b/src/main/java/frc/robot/commands/AmpAddOn/AmpPivotRelativeAngleControl.java
@@ -2,26 +2,26 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package frc.robot.commands.BarrelPivot;
+package frc.robot.commands.AmpAddOn;
 
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.XboxController;
+import frc.robot.testingdashboard.Command;
 import frc.robot.Constants;
 import frc.robot.OI;
-import frc.robot.subsystems.BarrelPivot;
-import frc.robot.testingdashboard.Command;;
+import frc.robot.subsystems.AmpAddOn;
 
-public class PivotRelativeAngleControl extends Command {
-  BarrelPivot m_barrelPivot;
+public class AmpPivotRelativeAngleControl extends Command {
+  AmpAddOn m_ampAddOn;
   XboxController m_operatorController;
 
-  /** Creates a new PivotRelativeAngleControl. */
-  public PivotRelativeAngleControl() {
-    super(BarrelPivot.getInstance(), "Basic", "PivotRelativeAngleControl");
-    m_barrelPivot = BarrelPivot.getInstance();
+  /** Creates a new AmpPivotRelativeAngleControl. */
+  public AmpPivotRelativeAngleControl() {
+    super(AmpAddOn.getInstance(), "Basic", "AmpPivotRelativeAngleControl");
+    m_ampAddOn = AmpAddOn.getInstance();
     m_operatorController = OI.getInstance().getOperatorXboxController();
     
-    addRequirements(m_barrelPivot);
+    addRequirements(m_ampAddOn);
   }
 
   // Called when the command is initially scheduled.
@@ -31,12 +31,12 @@ public class PivotRelativeAngleControl extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    double angle = m_barrelPivot.getTargetAngle();
-    double input = MathUtil.applyDeadband(m_operatorController.getLeftY(), Constants.kBPDeadband);
+    double angle = m_ampAddOn.getTargetAngle();
+    double input = MathUtil.applyDeadband(m_operatorController.getRightY(), Constants.kADeadband);
 
-    angle += input * Constants.BP_ANGLE_INCREMENT_DEGREES;
+    angle += input * Constants.A_ANGLE_INCREMENT_DEGREES;
 
-    m_barrelPivot.setTargetAngle(angle);
+    m_ampAddOn.setTargetAngle(angle);
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/AmpAddOn/AmpSetZeroAsCurrentPosition.java
+++ b/src/main/java/frc/robot/commands/AmpAddOn/AmpSetZeroAsCurrentPosition.java
@@ -1,0 +1,39 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.AmpAddOn;
+
+import frc.robot.testingdashboard.Command;
+import frc.robot.subsystems.AmpAddOn;
+
+public class AmpSetZeroAsCurrentPosition extends Command {
+  AmpAddOn m_ampAddOn;
+  /** Creates a new AmpSetZeroAsCurrentPosition. */
+  public AmpSetZeroAsCurrentPosition() {
+    super(AmpAddOn.getInstance(), "Basic", "AmpSetZeroAsCurrentPosition");
+    m_ampAddOn = AmpAddOn.getInstance();
+    
+    addRequirements(m_ampAddOn);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    m_ampAddOn.setZeroAsCurrentPosition();
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {}
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return true;
+  }
+}

--- a/src/main/java/frc/robot/commands/AmpAddOn/ScoreAmp.java
+++ b/src/main/java/frc/robot/commands/AmpAddOn/ScoreAmp.java
@@ -7,15 +7,25 @@ package frc.robot.commands.AmpAddOn;
 import frc.robot.Constants;
 import frc.robot.subsystems.AmpAddOn;
 import frc.robot.testingdashboard.Command;
+import frc.robot.testingdashboard.TDNumber;
 
 public class ScoreAmp extends Command {
   AmpAddOn m_AmpAddOn;
+
+  TDNumber m_RPM;
+  TDNumber m_enablePID;
+  TDNumber m_ampSpeed;
 
   /** Creates a new ScoreAmp. */
   public ScoreAmp() {
     super(AmpAddOn.getInstance(), "Basic", "ScoreAmp");
     m_AmpAddOn = AmpAddOn.getInstance();
-    // Use addRequirements() here to declare subsystem dependencies.
+
+    m_RPM = new TDNumber(m_AmpAddOn, "Amp Speed (RPM)", "RPM", Constants.AMP_SPEED_RPM);
+    m_enablePID = new TDNumber(m_AmpAddOn, "Amp Speed (RPM)", "Enable PID w 1");
+
+    m_ampSpeed = new TDNumber(m_AmpAddOn, "Amp Speed (Power)", "Speed", Constants.AMP_SPEED);
+    
     addRequirements(m_AmpAddOn);
   }
 
@@ -26,13 +36,23 @@ public class ScoreAmp extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    m_AmpAddOn.spinOut(Constants.AMP_SPEED);
+    if (m_enablePID.get() == 1) {
+      m_AmpAddOn.setSpeed(m_RPM.get(), false);
+    }
+    else {
+      m_AmpAddOn.spinOut(m_ampSpeed.get());
+    }
   }
 
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    m_AmpAddOn.spinStop();
+    if (m_enablePID.get() == 1) {
+      m_AmpAddOn.setSpeed(0, false);
+    }
+    else {
+      m_AmpAddOn.spinStop();
+    }
   }
 
   // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/AmpAddOn/UNScoreAmp.java
+++ b/src/main/java/frc/robot/commands/AmpAddOn/UNScoreAmp.java
@@ -6,17 +6,27 @@ package frc.robot.commands.AmpAddOn;
 
 import frc.robot.subsystems.AmpAddOn;
 import frc.robot.testingdashboard.Command;
+import frc.robot.testingdashboard.TDNumber;
 import frc.robot.Constants;
 
 
 public class UNScoreAmp extends Command {
   AmpAddOn m_AmpAddOn;
+
+  TDNumber m_RPM;
+  TDNumber m_enablePID;
+  TDNumber m_ampSpeed;
   
   /** Creates a new UNScoreAmp. */
   public UNScoreAmp() {
     super(AmpAddOn.getInstance(), "Basic", "UNScore");
     m_AmpAddOn = AmpAddOn.getInstance();
-    // Use addRequirements() here to declare subsystem dependencies.
+
+    m_RPM = new TDNumber(m_AmpAddOn, "Amp Speed (RPM)", "RPM", Constants.AMP_SPEED_RPM);
+    m_enablePID = new TDNumber(m_AmpAddOn, "Amp Speed (RPM)", "Enable PID w 1");
+
+    m_ampSpeed = new TDNumber(m_AmpAddOn, "Amp Speed (Power)", "Speed", Constants.AMP_SPEED);
+
     addRequirements(m_AmpAddOn);
   }
 
@@ -27,13 +37,23 @@ public class UNScoreAmp extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    m_AmpAddOn.spinIn(Constants.AMP_SPEED);
+    if (m_enablePID.get() == 1) {
+      m_AmpAddOn.setSpeed(m_RPM.get(), true);
+    }
+    else {
+      m_AmpAddOn.spinIn(m_ampSpeed.get());
+    }
   }
 
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    m_AmpAddOn.spinStop();
+    if (m_enablePID.get() == 1) {
+      m_AmpAddOn.setSpeed(0, false);
+    }
+    else {
+      m_AmpAddOn.spinStop();
+    }
   }
 
   // Returns true when the command should end.


### PR DESCRIPTION
This commit adds PID to the Amp Add-On's rollers. It also adds a relative angle control command which works with the right operator joystick to control the pivot of the Amp Add-On.