### PR TITLE
initializes SwerveDrive heading

### DIFF
--- a/src/main/java/frc/robot/commands/Drive/SwerveDrive.java
+++ b/src/main/java/frc/robot/commands/Drive/SwerveDrive.java
@@ -35,7 +35,10 @@ public class SwerveDrive extends Command {
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {}
+  public void initialize() {
+    m_operatorRotating = false;
+    m_TDheading.set(m_drive.getHeading());
+  }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override


### PR DESCRIPTION
In initialization, reset the heading so the PID tracking is already there.