### PR TITLE
adds an "Enabled" switch to each Testing Dashboard tab

### DIFF
--- a/src/main/java/frc/robot/testingdashboard/SubsystemBase.java
+++ b/src/main/java/frc/robot/testingdashboard/SubsystemBase.java
@@ -9,17 +9,22 @@ import java.util.ArrayList;
 public class SubsystemBase extends edu.wpi.first.wpilibj2.command.SubsystemBase {
 
   ArrayList<TDValue> m_values;
+  TDBoolean m_enabled;
   /** Creates a new Subsystem and registers it with the TestingDashboard. */
   public SubsystemBase(String name)
   {
     m_values = new ArrayList<TDValue>();
     setName(name);
     TestingDashboard.getInstance().registerTab(name);
+    // must do this after the subsystem is registered
+    m_enabled = new TDBoolean(this, "TestingDashboard", "Enabled", true);
   }
 
   @Override
   public void periodic() {
-    // This method will be called once per scheduler run
+
+    if (!m_enabled.get()) return;
+
     for(TDValue value : m_values)
     {
       value.post();

--- a/src/main/java/frc/robot/testingdashboard/TestingDashboard.java
+++ b/src/main/java/frc/robot/testingdashboard/TestingDashboard.java
@@ -239,6 +239,7 @@ public class TestingDashboard {
           String entryName = dataList.get(j);
           double defaultNumberValue = 0;
           String defaultStringValue = "";
+          boolean defaultBooleanValue = false;
           Sendable sendable;
           GenericEntry entry;
           int type = tdt.dataTable.getType(entryName);
@@ -257,8 +258,13 @@ public class TestingDashboard {
               sendable = tdt.dataTable.getDefaultSendableValue(entryName);
               layout.add(entryName, sendable);
               break;
+            case TestingDashboardDataTable.TYPE_BOOLEAN:
+              defaultBooleanValue = tdt.dataTable.getDefaultBooleanValue(entryName);
+              entry = layout.add(entryName, defaultBooleanValue).getEntry();
+              tdt.dataTable.addEntry(entryName, entry);
+              break;
             default:
-              System.out.println("ERROR: Type is " + type + "for data item \"" + entryName);
+              System.out.println("ERROR: Type is " + type + " for data item \"" + entryName + "\"");
               break;
           }
         }

--- a/src/main/java/frc/robot/testingdashboard/TestingDashboardDataTable.java
+++ b/src/main/java/frc/robot/testingdashboard/TestingDashboardDataTable.java
@@ -23,6 +23,7 @@ public class TestingDashboardDataTable {
   public static final int TYPE_NUMBER = 0;
   public static final int TYPE_STRING = 1;
   public static final int TYPE_SENDABLE = 2;
+  public static final int TYPE_BOOLEAN = 3;
   Hashtable<String, ArrayList<String>> table;
   ArrayList<String> names;
   Hashtable<String, Integer> type;
@@ -80,7 +81,7 @@ public class TestingDashboardDataTable {
 
   public void addDefaultBooleanValue(String name, boolean value) {
     if (names.contains(name)) {
-        type.put(name,Integer.valueOf(TYPE_NUMBER));
+        type.put(name,Integer.valueOf(TYPE_BOOLEAN));
         defaultBoolean.put(name,Boolean.valueOf(value));
     }
   }


### PR DESCRIPTION
Each registered subsystem includes a "TestingDashboard/Enabled" element. The default is true (Enabled). If the switch is turned off, the subsystem will stop posting new values to the dashboard. This may be helpful in competition when we want to limit our bandwidth usage.

This also changes how TDBoolean is registered (it was a number before).