### PR TITLE
debugs BarrelPivot's relative angle control

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -14,13 +14,18 @@ import frc.robot.commands.AmpAddOn.ScoreAmp;
 import frc.robot.commands.AmpAddOn.UNScoreAmp;
 import frc.robot.commands.Barrel.SpinBarrelBackward;
 import frc.robot.commands.Barrel.SpinBarrelForward;
+import frc.robot.commands.BarrelPivot.PivotDownwards;
 import frc.robot.commands.BarrelPivot.PivotRelativeAngleControl;
+import frc.robot.commands.BarrelPivot.PivotUpwards;
 import frc.robot.commands.BarrelPivot.SetZeroAsCurrentPosition;
+import frc.robot.commands.BarrelPivot.resetTargetAngle;
 import frc.robot.commands.Drive.DriveToPose;
 import frc.robot.commands.Drive.SwerveDrive;
 import frc.robot.commands.Drive.TargetDrive;
 import frc.robot.commands.Drive.TurnToRotation;
 import frc.robot.commands.Drive.TurnToTarget;
+import frc.robot.commands.Elevator.Climb;
+import frc.robot.commands.Elevator.UNClimb;
 import frc.robot.commands.Intake.Consume;
 import frc.robot.commands.Intake.Expel;
 import frc.robot.commands.Lights.BlinkLights;
@@ -107,9 +112,9 @@ public class RobotContainer {
     m_robotDrive.setDefaultCommand(new SwerveDrive(m_driveInputs));
 
     m_ampAddOn = AmpAddOn.getInstance();
-    if (RobotMap.A_ENABLED) {
-      m_ampAddOn.setDefaultCommand(new AmpPivotRelativeAngleControl());
-    }
+    // if (RobotMap.A_ENABLED) {
+    //   m_ampAddOn.setDefaultCommand(new AmpPivotRelativeAngleControl());
+    // }
 
     m_barrelPivot = BarrelPivot.getInstance();
     if (RobotMap.BP_ENABLED) {
@@ -141,6 +146,7 @@ public class RobotContainer {
     new ScoreAmp();
     new UNScoreAmp();
     new AmpSetZeroAsCurrentPosition();
+    new AmpPivotRelativeAngleControl();
 
     // Barrel commands
     new SpinBarrelForward();
@@ -148,6 +154,14 @@ public class RobotContainer {
 
     // BarrelPivot commands
     new SetZeroAsCurrentPosition();
+    new resetTargetAngle();
+    new PivotRelativeAngleControl();
+    new PivotUpwards();
+    new PivotDownwards();
+
+    // Elevator commands
+    new Climb();
+    new UNClimb();
 
     // Intake commands
     new Consume();

--- a/src/main/java/frc/robot/commands/BarrelPivot/PivotRelativeAngleControl.java
+++ b/src/main/java/frc/robot/commands/BarrelPivot/PivotRelativeAngleControl.java
@@ -32,7 +32,8 @@ public class PivotRelativeAngleControl extends Command {
   @Override
   public void execute() {
     double angle = m_barrelPivot.getTargetAngle();
-    double input = MathUtil.applyDeadband(m_operatorController.getLeftY(), Constants.kBPDeadband);
+    // upward input on joystick will move Barrel Pivot upwards and vice versa
+    double input = -MathUtil.applyDeadband(m_operatorController.getLeftY(), Constants.kBPDeadband);
 
     angle += input * Constants.BP_ANGLE_INCREMENT_DEGREES;
 

--- a/src/main/java/frc/robot/commands/BarrelPivot/resetTargetAngle.java
+++ b/src/main/java/frc/robot/commands/BarrelPivot/resetTargetAngle.java
@@ -1,0 +1,39 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.BarrelPivot;
+
+import frc.robot.subsystems.BarrelPivot;
+import frc.robot.testingdashboard.Command;
+
+public class resetTargetAngle extends Command {
+  BarrelPivot m_barrelPivot;
+
+  /** Creates a new resetTargetAngle. */
+  public resetTargetAngle() {
+    super(BarrelPivot.getInstance(), "Basic", "resetTargetAngle");
+    m_barrelPivot = BarrelPivot.getInstance();
+    addRequirements(m_barrelPivot);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    m_barrelPivot.resetTargetAngle();
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {}
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return true;
+  }
+}

--- a/src/main/java/frc/robot/commands/ShootSpeaker.java
+++ b/src/main/java/frc/robot/commands/ShootSpeaker.java
@@ -1,0 +1,93 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import frc.robot.commands.Barrel.SpinBarrelForward;
+import frc.robot.subsystems.Shooter;
+import frc.robot.testingdashboard.Command;
+
+public class ShootSpeaker extends Command {
+  enum State {
+    INIT,
+    SCHEDULE_SPIN_BARREL_FORWARD,
+    WAIT_FOR_SHOOTER_NOTE_DETECTION,
+    SPIN_BARREL_FORWARD_UNTIL_RELEASE,
+    DONE
+  }
+
+  SpinBarrelForward m_spinBarrelForward;
+  
+  Shooter m_shooter;
+
+  private boolean m_isFinished;
+  private State m_state;
+
+  /** Creates a new ShootSpeaker. */
+  public ShootSpeaker() {
+    super(Shooter.getInstance(), "", "ShootSpeaker");
+
+    m_state = State.INIT;
+    m_isFinished = false;
+
+    m_shooter = Shooter.getInstance();
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    m_state = State.INIT;
+    m_isFinished = false;
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    switch (m_state) {
+      case INIT:
+        if (m_shooter.isAtSetSpeed()) {
+          m_state = State.SCHEDULE_SPIN_BARREL_FORWARD;
+        }
+        break;
+
+      case SCHEDULE_SPIN_BARREL_FORWARD:
+        m_spinBarrelForward.schedule();
+        m_state = State.WAIT_FOR_SHOOTER_NOTE_DETECTION;
+        break;
+
+      case WAIT_FOR_SHOOTER_NOTE_DETECTION:
+        if (m_shooter.hasNote()) {
+          m_state = State.SPIN_BARREL_FORWARD_UNTIL_RELEASE;
+        }
+        break;
+
+      case SPIN_BARREL_FORWARD_UNTIL_RELEASE:
+        if (!m_shooter.hasNote()) {
+          m_state = State.DONE;
+        }
+        break;
+
+      case DONE:
+        m_isFinished = true;
+        break;
+      
+      default:
+        break;
+    }
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    if (m_spinBarrelForward.isScheduled()) {
+      m_spinBarrelForward.cancel();
+    }
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return m_isFinished;
+  }
+}

--- a/src/main/java/frc/robot/subsystems/BarrelPivot.java
+++ b/src/main/java/frc/robot/subsystems/BarrelPivot.java
@@ -22,7 +22,6 @@ public class BarrelPivot extends SubsystemBase {
   private static BarrelPivot m_barrelPivot;
 
   TDNumber m_targetAngle;
-
   TDNumber m_P;
   TDNumber m_I;
   TDNumber m_D;
@@ -33,6 +32,9 @@ public class BarrelPivot extends SubsystemBase {
   CANSparkMax m_BPRightSparkMax;
   SparkPIDController m_SparkPIDController;
   AbsoluteEncoder m_absoluteEncoder;
+
+  TDNumber m_motorTemperature;
+  TDNumber m_currentOutput;
 
   /** Creates a new BarrelPivot. */
   private BarrelPivot() {
@@ -75,6 +77,10 @@ public class BarrelPivot extends SubsystemBase {
 
       m_encoderValueRotations = new TDNumber(this, "Encoder Values", "Rotations", getAngle() / Constants.kBPEncoderPositionFactorDegrees);
       m_encoderValueAngleDegrees = new TDNumber(this, "Encoder Values", "Angle (degrees)", getAngle());
+
+      // for SPARK w/absolute encoder
+      m_motorTemperature = new TDNumber(this, "Safety", "Motor Temperature (fahrenheit)", getMotorTemperature());
+      m_currentOutput = new TDNumber(this, "Safety", "Current Output", getCurrentOutput());
     }
   }
 
@@ -125,6 +131,25 @@ public class BarrelPivot extends SubsystemBase {
     }
   }
 
+  public double getMotorTemperature() {
+    if (m_BPLeftSparkMax != null) {
+      // Converting Celsius to Fahrenheit
+      return (m_BPLeftSparkMax.getMotorTemperature() * 9/5) + 32;
+    }
+    else {
+      return 0;
+    }
+  }
+
+  public double getCurrentOutput() {
+    if (m_BPLeftSparkMax != null) {
+      return m_BPLeftSparkMax.getOutputCurrent();
+    }
+    else {
+      return 0;
+    }
+  }
+
   @Override
   public void periodic() {
     if (RobotMap.BP_ENABLED) {
@@ -136,6 +161,9 @@ public class BarrelPivot extends SubsystemBase {
 
       m_encoderValueRotations.set(getAngle() / Constants.kBPEncoderPositionFactorDegrees);
       m_encoderValueAngleDegrees.set(getAngle());
+
+      m_motorTemperature.set(getMotorTemperature());
+      m_currentOutput.set(getCurrentOutput());
     }
 
     super.periodic();

--- a/src/main/java/frc/robot/subsystems/BarrelPivot.java
+++ b/src/main/java/frc/robot/subsystems/BarrelPivot.java
@@ -94,13 +94,17 @@ public class BarrelPivot extends SubsystemBase {
     m_SparkPIDController.setReference(m_targetAngle.get(), ControlType.kPosition);
   }
 
+  public void resetTargetAngle() {
+    setTargetAngle(getAngle());
+  }
+
   public double getTargetAngle() {
     return m_targetAngle.get();
   }
 
   public void setZeroAsCurrentPosition() {
     m_absoluteEncoder.setZeroOffset(getAngle());
-    m_targetAngle.set(0);
+    resetTargetAngle(); 
   }
 
   public void pivotUpwards() {

--- a/src/main/java/frc/robot/subsystems/BarrelPivot.java
+++ b/src/main/java/frc/robot/subsystems/BarrelPivot.java
@@ -69,6 +69,10 @@ public class BarrelPivot extends SubsystemBase {
       m_absoluteEncoder.setPositionConversionFactor(Constants.kBPEncoderPositionFactorDegrees);
       m_targetAngle = new TDNumber(this, "Encoder Values", "Target Angle", getAngle());
 
+      m_SparkPIDController.setPositionPIDWrappingEnabled(true);
+      m_SparkPIDController.setPositionPIDWrappingMinInput(0);
+      m_SparkPIDController.setPositionPIDWrappingMaxInput(Constants.DEGREES_PER_REVOLUTION);
+
       m_encoderValueRotations = new TDNumber(this, "Encoder Values", "Rotations", getAngle() / Constants.kBPEncoderPositionFactorDegrees);
       m_encoderValueAngleDegrees = new TDNumber(this, "Encoder Values", "Angle (degrees)", getAngle());
     }
@@ -86,7 +90,7 @@ public class BarrelPivot extends SubsystemBase {
   }
 
   public void setTargetAngle(double angle) {
-    m_targetAngle.set(angle);
+    m_targetAngle.set(angle % Constants.DEGREES_PER_REVOLUTION);
     m_SparkPIDController.setReference(m_targetAngle.get(), ControlType.kPosition);
   }
 


### PR DESCRIPTION
Everything that worked for the BarrelPivot during the 2/23 meeting has been pushed, with a few requested additions (current outputs of motors, reset targetAngle command) and the ShootSpeaker state machine.