### PR TITLE
updates SparkMax PID tuning values only when they change

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -56,7 +56,7 @@ public final class Constants {
     public static final double kADeadband = 0.05;
 
     // Defines Barrel constants
-    public static final boolean kEnableBarrelPIDTuning = false;
+    public static final boolean kEnableBarrelPIDTuning = true;
     public static final double kBarrelP = 0;
     public static final double kBarrelI = 0;
     public static final double kBarrelD = 0;
@@ -89,7 +89,7 @@ public final class Constants {
     public static final double ELEVATOR_SPEED = 0.2;
     public static final double ELEVATOR_SPEED_RPM = 0;
 
-    public static final boolean kEnableElevatorPivotPIDTuning = false;
+    public static final boolean kEnableElevatorPivotPIDTuning = true;
     public static final double kElevatorPivotP = 0;
     public static final double kElevatorPivotI = 0;
     public static final double kElevatorPivotD = 0;
@@ -180,7 +180,7 @@ public final class Constants {
     public static final double kDriveDeadband = 0.2;
 
     // Defines Intake constants
-    public static final boolean kEnableIntakePIDTuning = false;
+    public static final boolean kEnableIntakePIDTuning = true;
     public static final double kIntakeP = 0;
     public static final double kIntakeI = 0;
     public static final double kIntakeD = 0;
@@ -192,7 +192,7 @@ public final class Constants {
     public static final int LED_LENGTH = 42; // number of LEDs
 
     // Defines Shooter constants
-    public static final boolean kEnableShooterPIDTuning = false;
+    public static final boolean kEnableShooterPIDTuning = true;
     public static final double kShooterP = 0;
     public static final double kShooterI = 0;
     public static final double kShooterD = 0;

--- a/src/main/java/frc/robot/subsystems/AmpAddOn.java
+++ b/src/main/java/frc/robot/subsystems/AmpAddOn.java
@@ -24,15 +24,22 @@ import frc.robot.utils.NoteProximitySensor;
 public class AmpAddOn extends SubsystemBase {
   private static AmpAddOn m_AmpAddOn;
 
-  TDNumber m_P;
-  TDNumber m_I;
-  TDNumber m_D;
+  TDNumber m_TDrollerP;
+  TDNumber m_TDrollerI;
+  TDNumber m_TDrollerD;
+  double m_rollerP = Constants.kAmpP;
+  double m_rollerI = Constants.kAmpI;
+  double m_rollerD = Constants.kAmpD;
 
   TDNumber m_targetAngle;
 
-  TDNumber m_PivotP;
-  TDNumber m_PivotI;
-  TDNumber m_PivotD;
+  TDNumber m_TDpivotP;
+  TDNumber m_TDpivotI;
+  TDNumber m_TDpivotD;
+  double m_pivotP = Constants.kAmpPivotP;
+  double m_pivotI = Constants.kAmpPivotI;
+  double m_pivotD = Constants.kAmpPivotD;
+
   TDNumber m_encoderValueRotations;
   TDNumber m_encoderValueAngleDegrees;
 
@@ -61,23 +68,23 @@ public class AmpAddOn extends SubsystemBase {
       
       m_SparkPIDController = m_CanSparkMax.getPIDController();
 
-      m_P = new TDNumber(this, "Amp Roller PID", "P", Constants.kAmpP);
-      m_I = new TDNumber(this, "Amp Roller PID", "I", Constants.kAmpI);
-      m_D = new TDNumber(this, "Amp Roller PID", "D", Constants.kAmpD);
+      m_TDrollerP = new TDNumber(this, "Amp Roller PID", "P", Constants.kAmpP);
+      m_TDrollerI = new TDNumber(this, "Amp Roller PID", "I", Constants.kAmpI);
+      m_TDrollerD = new TDNumber(this, "Amp Roller PID", "D", Constants.kAmpD);
 
-      m_SparkPIDController.setP(m_P.get());
-      m_SparkPIDController.setI(m_I.get());
-      m_SparkPIDController.setD(m_D.get());
+      m_SparkPIDController.setP(m_rollerP);
+      m_SparkPIDController.setI(m_rollerI);
+      m_SparkPIDController.setD(m_rollerD);
 
       m_PivotSparkPIDController = m_PivotCanSparkMax.getPIDController();
 
-      m_PivotP = new TDNumber(this, "Amp Pivot PID", "P", Constants.kAmpPivotP);
-      m_PivotI = new TDNumber(this, "Amp Pivot PID", "I", Constants.kAmpPivotI);
-      m_PivotD = new TDNumber(this, "Amp Pivot PID", "D", Constants.kAmpPivotD);
+      m_TDpivotP = new TDNumber(this, "Amp Pivot PID", "P", Constants.kAmpPivotP);
+      m_TDpivotI = new TDNumber(this, "Amp Pivot PID", "I", Constants.kAmpPivotI);
+      m_TDpivotD = new TDNumber(this, "Amp Pivot PID", "D", Constants.kAmpPivotD);
 
-      m_PivotSparkPIDController.setP(m_PivotP.get());
-      m_PivotSparkPIDController.setI(m_PivotI.get());
-      m_PivotSparkPIDController.setD(m_PivotD.get());
+      m_PivotSparkPIDController.setP(m_pivotP);
+      m_PivotSparkPIDController.setI(m_pivotI);
+      m_PivotSparkPIDController.setD(m_pivotD);
 
       m_absoluteEncoder = m_PivotCanSparkMax.getAbsoluteEncoder(Type.kDutyCycle);
       m_PivotSparkPIDController.setFeedbackDevice(m_absoluteEncoder);
@@ -181,13 +188,37 @@ public class AmpAddOn extends SubsystemBase {
   public void periodic() {
     if (RobotMap.A_ENABLED) {
       if (Constants.kEnableAmpAddOnPIDTuning) {
-        m_SparkPIDController.setP(m_P.get());
-        m_SparkPIDController.setI(m_I.get());
-        m_SparkPIDController.setD(m_D.get());
-
-        m_PivotSparkPIDController.setP(m_PivotP.get());
-        m_PivotSparkPIDController.setI(m_PivotI.get());
-        m_PivotSparkPIDController.setD(m_PivotD.get());
+        double tmp = m_TDrollerP.get();
+        if (tmp != m_rollerP) {
+          m_SparkPIDController.setP(tmp);
+          m_rollerP = tmp;
+        }
+        tmp = m_TDrollerI.get();
+        if (tmp != m_rollerI) {
+          m_SparkPIDController.setI(tmp);
+          m_rollerI = tmp;
+        }
+        tmp = m_TDrollerD.get();
+        if (tmp != m_rollerD) {
+          m_SparkPIDController.setD(tmp);
+          m_rollerD = tmp;
+        }
+      
+        tmp = m_TDpivotP.get();
+        if (tmp != m_pivotP) {
+          m_PivotSparkPIDController.setP(tmp);
+          m_pivotP = tmp;
+        }
+        tmp = m_TDpivotI.get();
+        if (tmp != m_pivotI) {
+          m_PivotSparkPIDController.setI(tmp);
+          m_pivotI = tmp;
+        }
+        tmp = m_TDpivotD.get();
+        if (tmp != m_pivotD) {
+          m_PivotSparkPIDController.setD(tmp);
+          m_pivotD = tmp;
+        }
       }
 
       m_encoderValueRotations.set(getAngle() / Constants.kBPEncoderPositionFactorDegrees);

--- a/src/main/java/frc/robot/subsystems/Barrel.java
+++ b/src/main/java/frc/robot/subsystems/Barrel.java
@@ -18,9 +18,12 @@ import frc.robot.utils.NoteProximitySensor;
 public class Barrel extends SubsystemBase {
   private static Barrel m_barrel;
 
-  TDNumber m_P;
-  TDNumber m_I;
-  TDNumber m_D;
+  TDNumber m_TDrollerP;
+  TDNumber m_TDrollerI;
+  TDNumber m_TDrollerD;
+  double m_rollerP = Constants.kBarrelP;
+  double m_rollerI = Constants.kBarrelI;
+  double m_rollerD = Constants.kBarrelD;
 
   CANSparkMax m_CanSparkMax;
   SparkPIDController m_SparkPIDController;
@@ -38,13 +41,13 @@ public class Barrel extends SubsystemBase {
 
       m_SparkPIDController = m_CanSparkMax.getPIDController();
 
-      m_P = new TDNumber(this, "BarrelPID", "P", Constants.kBarrelP);
-      m_I = new TDNumber(this, "BarrelPID", "I", Constants.kBarrelI);
-      m_D = new TDNumber(this, "BarrelPID", "D", Constants.kBarrelD);
+      m_TDrollerP = new TDNumber(this, "BarrelPID", "P", Constants.kBarrelP);
+      m_TDrollerI = new TDNumber(this, "BarrelPID", "I", Constants.kBarrelI);
+      m_TDrollerD = new TDNumber(this, "BarrelPID", "D", Constants.kBarrelD);
 
-      m_SparkPIDController.setP(m_P.get());
-      m_SparkPIDController.setI(m_I.get());
-      m_SparkPIDController.setD(m_D.get());
+      m_SparkPIDController.setP(m_rollerP);
+      m_SparkPIDController.setI(m_rollerI);
+      m_SparkPIDController.setD(m_rollerD);
 
       m_NoteProximitySensor = new NoteProximitySensor(RobotMap.B_NOTE_SENSOR, this);
     }
@@ -98,9 +101,22 @@ public class Barrel extends SubsystemBase {
     // This method will be called once per scheduler run
     if (Constants.kEnableBarrelPIDTuning && 
         m_CanSparkMax != null) {
-      m_SparkPIDController.setP(m_P.get());
-      m_SparkPIDController.setI(m_I.get());
-      m_SparkPIDController.setD(m_D.get());
+
+      double tmp = m_TDrollerP.get();
+      if (tmp != m_rollerP) {
+        m_SparkPIDController.setP(tmp);
+        m_rollerP = tmp;
+      }
+      tmp = m_TDrollerI.get();
+      if (tmp != m_rollerI) {
+        m_SparkPIDController.setI(tmp);
+        m_rollerI = tmp;
+      }
+      tmp = m_TDrollerD.get();
+      if (tmp != m_rollerD) {
+        m_SparkPIDController.setD(tmp);
+        m_rollerD = tmp;
+      }
     }
 
     super.periodic();

--- a/src/main/java/frc/robot/subsystems/BarrelPivot.java
+++ b/src/main/java/frc/robot/subsystems/BarrelPivot.java
@@ -22,9 +22,12 @@ public class BarrelPivot extends SubsystemBase {
   private static BarrelPivot m_barrelPivot;
 
   TDNumber m_targetAngle;
-  TDNumber m_P;
-  TDNumber m_I;
-  TDNumber m_D;
+  TDNumber m_TDangleP;
+  TDNumber m_TDangleI;
+  TDNumber m_TDangleD;
+  double   m_angleP = Constants.kBarrelPivotP;
+  double   m_angleI = Constants.kBarrelPivotI;
+  double   m_angleD = Constants.kBarrelPivotD;
   TDNumber m_encoderValueRotations;
   TDNumber m_encoderValueAngleDegrees;
   
@@ -56,13 +59,13 @@ public class BarrelPivot extends SubsystemBase {
 
       m_SparkPIDController = m_BPLeftSparkMax.getPIDController();
 
-      m_P = new TDNumber(this, "Barrel Pivot PID", "P", Constants.kBarrelPivotP);
-      m_I = new TDNumber(this, "Barrel Pivot PID", "I", Constants.kBarrelPivotI);
-      m_D = new TDNumber(this, "Barrel Pivot PID", "D", Constants.kBarrelPivotD);
+      m_TDangleP = new TDNumber(this, "Barrel Pivot PID", "P", Constants.kBarrelPivotP);
+      m_TDangleI = new TDNumber(this, "Barrel Pivot PID", "I", Constants.kBarrelPivotI);
+      m_TDangleD = new TDNumber(this, "Barrel Pivot PID", "D", Constants.kBarrelPivotD);
 
-      m_SparkPIDController.setP(m_P.get());
-      m_SparkPIDController.setI(m_I.get());
-      m_SparkPIDController.setD(m_D.get());
+      m_SparkPIDController.setP(m_angleP);
+      m_SparkPIDController.setI(m_angleI);
+      m_SparkPIDController.setD(m_angleD);
 
       m_absoluteEncoder = m_BPLeftSparkMax.getAbsoluteEncoder(Type.kDutyCycle);
       m_SparkPIDController.setFeedbackDevice(m_absoluteEncoder);
@@ -154,9 +157,21 @@ public class BarrelPivot extends SubsystemBase {
   public void periodic() {
     if (RobotMap.BP_ENABLED) {
       if (Constants.kEnableBarrelPivotPIDTuning) {
-        m_SparkPIDController.setP(m_P.get());
-        m_SparkPIDController.setI(m_I.get());
-        m_SparkPIDController.setD(m_D.get());
+        double tmp = m_TDangleP.get();
+        if (tmp != m_angleP) {
+          m_SparkPIDController.setP(tmp);
+          m_angleP = tmp;
+        }
+        tmp = m_TDangleI.get();
+        if (tmp != m_angleI) {
+          m_SparkPIDController.setI(tmp);
+          m_angleI = tmp;
+        }
+        tmp = m_TDangleD.get();
+        if (tmp != m_angleD) {
+          m_SparkPIDController.setD(tmp);
+          m_angleD = tmp;
+        }
       }
 
       m_encoderValueRotations.set(getAngle() / Constants.kBPEncoderPositionFactorDegrees);

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -17,9 +17,12 @@ import frc.robot.testingdashboard.TDNumber;
 public class Elevator extends SubsystemBase {
   private static Elevator m_Elevator;
 
-  TDNumber m_P;
-  TDNumber m_I;
-  TDNumber m_D;
+  TDNumber m_TDclimbP;
+  TDNumber m_TDclimbI;
+  TDNumber m_TDclimbD;
+  double   m_climbP = Constants.kElevatorPivotP;
+  double   m_climbI = Constants.kElevatorPivotI;
+  double   m_climbD = Constants.kElevatorPivotD;
 
   CANSparkMax m_LeftCanSparkMax;
   CANSparkMax m_RightCanSparkMax;
@@ -29,6 +32,10 @@ public class Elevator extends SubsystemBase {
   public Elevator() {
     super("Elevator");
     if(RobotMap.E_ELEVATOR_ENABLED) {
+
+      m_TDclimbP = new TDNumber(this, "Climber PID", "P", Constants.kElevatorPivotP);
+      m_TDclimbI = new TDNumber(this, "Climber PID", "I", Constants.kElevatorPivotI);
+      m_TDclimbD = new TDNumber(this, "Climber PID", "D", Constants.kElevatorPivotD);
       m_LeftCanSparkMax = new CANSparkMax(RobotMap.E_MOTOR_LEFT, MotorType.kBrushless);
       m_RightCanSparkMax = new CANSparkMax(RobotMap.E_MOTOR_RIGHT, MotorType.kBrushless);
 
@@ -40,9 +47,9 @@ public class Elevator extends SubsystemBase {
 
       m_SparkPIDController = m_LeftCanSparkMax.getPIDController();
 
-      m_SparkPIDController.setP(m_P.get());
-      m_SparkPIDController.setI(m_I.get());
-      m_SparkPIDController.setD(m_D.get());
+      m_SparkPIDController.setP(m_climbP);
+      m_SparkPIDController.setI(m_climbI);
+      m_SparkPIDController.setD(m_climbD);
 
     }
   }
@@ -85,9 +92,21 @@ public class Elevator extends SubsystemBase {
   public void periodic() {
     // This method will be called once per scheduler run
     if (Constants.kEnableElevatorPivotPIDTuning && m_LeftCanSparkMax != null) {
-      m_SparkPIDController.setP(m_P.get());
-      m_SparkPIDController.setI(m_I.get());
-      m_SparkPIDController.setD(m_D.get());
+      double tmp = m_TDclimbP.get();
+      if (tmp != m_climbP) {
+        m_SparkPIDController.setP(tmp);
+        m_climbP = tmp;
+      }
+      tmp = m_TDclimbI.get();
+      if (tmp != m_climbI) {
+        m_SparkPIDController.setI(tmp);
+        m_climbI = tmp;
+      }
+      tmp = m_TDclimbD.get();
+      if (tmp != m_climbD) {
+        m_SparkPIDController.setD(tmp);
+        m_climbD = tmp;
+      }
     }
     
     super.periodic();

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -19,9 +19,12 @@ import frc.robot.utils.NoteProximitySensor;
 public class Intake extends SubsystemBase {
   private static Intake m_intake;
 
-  TDNumber m_P;
-  TDNumber m_I;
-  TDNumber m_D;
+  TDNumber m_TDintakeP;
+  TDNumber m_TDintakeI;
+  TDNumber m_TDintakeD;
+  double   m_intakeP = Constants.kIntakeP;
+  double   m_intakeI = Constants.kIntakeI;
+  double   m_intakeD = Constants.kIntakeD;
   
   CANSparkMax m_ILeftSparkMax;
   CANSparkMax m_IRightSparkMax;
@@ -48,13 +51,13 @@ public class Intake extends SubsystemBase {
 
       m_SparkPIDController = m_ILeftSparkMax.getPIDController();
 
-      m_P = new TDNumber(this, "IntakePID", "P", Constants.kIntakeP);
-      m_I = new TDNumber(this, "IntakePID", "I", Constants.kIntakeI);
-      m_D = new TDNumber(this, "IntakePID", "D", Constants.kIntakeD);
+      m_TDintakeP = new TDNumber(this, "IntakePID", "P", Constants.kIntakeP);
+      m_TDintakeI = new TDNumber(this, "IntakePID", "I", Constants.kIntakeI);
+      m_TDintakeD = new TDNumber(this, "IntakePID", "D", Constants.kIntakeD);
 
-      m_SparkPIDController.setP(m_P.get());
-      m_SparkPIDController.setI(m_I.get());
-      m_SparkPIDController.setD(m_D.get());
+      m_SparkPIDController.setP(m_intakeP);
+      m_SparkPIDController.setI(m_intakeI);
+      m_SparkPIDController.setD(m_intakeD);
 
       m_NoteProximitySensor = new NoteProximitySensor(RobotMap.I_NOTE_SENSOR, this);
     }
@@ -104,9 +107,21 @@ public class Intake extends SubsystemBase {
   public void periodic() {
     if (Constants.kEnableIntakePIDTuning && 
         m_SparkPIDController != null) {
-      m_SparkPIDController.setP(m_P.get());
-      m_SparkPIDController.setI(m_I.get());
-      m_SparkPIDController.setD(m_D.get());
+          double tmp = m_TDintakeP.get();
+          if (tmp != m_intakeP) {
+            m_SparkPIDController.setP(tmp);
+            m_intakeP = tmp;
+          }
+          tmp = m_TDintakeI.get();
+          if (tmp != m_intakeI) {
+            m_SparkPIDController.setI(tmp);
+            m_intakeI = tmp;
+          }
+          tmp = m_TDintakeD.get();
+          if (tmp != m_intakeD) {
+            m_SparkPIDController.setD(tmp);
+            m_intakeD = tmp;
+          }
     }
     
     super.periodic();

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -21,9 +21,12 @@ import frc.robot.utils.NoteProximitySensor;
 public class Shooter extends SubsystemBase {
   private static Shooter m_shooter;
 
-  TDNumber m_P;
-  TDNumber m_I;
-  TDNumber m_D;
+  TDNumber m_TDshootP;
+  TDNumber m_TDshootI;
+  TDNumber m_TDshootD;
+  double   m_shootP = Constants.kShooterP;
+  double   m_shootI = Constants.kShooterI;
+  double   m_shootD = Constants.kShooterD;
   
   CANSparkMax m_SLeftSparkMax;
   CANSparkMax m_SRightSparkMax;
@@ -55,17 +58,17 @@ public class Shooter extends SubsystemBase {
       m_leftSpeedSetpoint = 0;
       m_rightSpeedSetpoint = 0;
 
-      m_P = new TDNumber(this, "ShooterPID", "P", Constants.kShooterP);
-      m_I = new TDNumber(this, "ShooterPID", "I", Constants.kShooterI);
-      m_D = new TDNumber(this, "ShooterPID", "D", Constants.kShooterD);
+      m_TDshootP = new TDNumber(this, "ShooterPID", "P", Constants.kShooterP);
+      m_TDshootI = new TDNumber(this, "ShooterPID", "I", Constants.kShooterI);
+      m_TDshootD = new TDNumber(this, "ShooterPID", "D", Constants.kShooterD);
 
-      m_LeftSparkPIDController.setP(m_P.get());
-      m_LeftSparkPIDController.setI(m_I.get());
-      m_LeftSparkPIDController.setD(m_D.get());
+      m_LeftSparkPIDController.setP(m_shootP);
+      m_LeftSparkPIDController.setI(m_shootI);
+      m_LeftSparkPIDController.setD(m_shootD);
 
-      m_RightSparkPIDController.setP(m_P.get());
-      m_RightSparkPIDController.setI(m_I.get());
-      m_RightSparkPIDController.setD(m_D.get());
+      m_RightSparkPIDController.setP(m_shootP);
+      m_RightSparkPIDController.setI(m_shootI);
+      m_RightSparkPIDController.setD(m_shootD);
 
       m_NoteProximitySensor = new NoteProximitySensor(RobotMap.S_NOTE_SENSOR, this);
     }
@@ -138,13 +141,32 @@ public class Shooter extends SubsystemBase {
     if (Constants.kEnableShooterPIDTuning && 
         m_LeftSparkPIDController != null &&
         m_RightSparkPIDController != null) {
-      m_LeftSparkPIDController.setP(m_P.get());
-      m_LeftSparkPIDController.setI(m_I.get());
-      m_LeftSparkPIDController.setD(m_D.get());
+      m_LeftSparkPIDController.setP(m_shootP);
+      m_LeftSparkPIDController.setI(m_shootI);
+      m_LeftSparkPIDController.setD(m_shootD);
 
-      m_RightSparkPIDController.setP(m_P.get());
-      m_RightSparkPIDController.setI(m_I.get());
-      m_RightSparkPIDController.setD(m_D.get());
+      m_RightSparkPIDController.setP(m_shootP);
+      m_RightSparkPIDController.setI(m_shootI);
+      m_RightSparkPIDController.setD(m_shootD);
+
+      double tmp = m_TDshootP.get();
+      if (tmp != m_shootP) {
+        m_LeftSparkPIDController.setP(tmp);
+        m_RightSparkPIDController.setP(tmp);
+        m_shootP = tmp;
+      }
+      tmp = m_TDshootI.get();
+      if (tmp != m_shootI) {
+        m_LeftSparkPIDController.setI(tmp);
+        m_RightSparkPIDController.setI(tmp);
+        m_shootI = tmp;
+      }
+      tmp = m_TDshootD.get();
+      if (tmp != m_shootD) {
+        m_LeftSparkPIDController.setD(tmp);
+        m_RightSparkPIDController.setD(tmp);
+        m_shootD = tmp;
+      }      
     }
 
     super.periodic();


### PR DESCRIPTION
This caches the PID tuning values for the AmpAddOn, Barrel, BarrelPivot, Elevator, Intake, and Shooter drives. On each periodic cycle, compares the set value with the testing dashboard value, and updates the motor controllers only when the values change.

Also enables PID tuning for those subsystems.