### PR TITLE
reduces the frequency of setReference() on SparkMax

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -49,6 +49,8 @@ public final class Constants {
     public static final double kAmpPivotD = 0;
 
     public static final double kAEncoderPositionFactorDegrees = DEGREES_PER_REVOLUTION;
+    public static final double kAPivotUpperLimitDegrees = 280;
+    public static final double kAPivotLowerLimitDegrees = 60;
     public static final double kAPivotToleranceDegrees = 2;
     public static final double kAPivotIntakePositionDegrees = 64;
     public static final double kAPivotUpPositionDegrees = 275;
@@ -71,6 +73,8 @@ public final class Constants {
     public static final double kBarrelPivotP = 0.06;
     public static final double kBarrelPivotI = 0.000001;
     public static final double kBarrelPivotD = 0;
+    public static final double kBarrelPivotLowerLimitDegrees = 60;
+    public static final double kBarrelPivotUpperLimitDegrees = 150;
 
     public static final double kBPEncoderPositionFactorDegrees = DEGREES_PER_REVOLUTION;
 

--- a/src/main/java/frc/robot/subsystems/Barrel.java
+++ b/src/main/java/frc/robot/subsystems/Barrel.java
@@ -33,7 +33,7 @@ public class Barrel extends SubsystemBase {
   SparkPIDController m_SparkPIDController;
 
   NoteProximitySensor m_NoteProximitySensor;
-  
+
   /** Creates a new Barrel. */
   private Barrel() {
     super("Barrel");

--- a/src/main/java/frc/robot/subsystems/Barrel.java
+++ b/src/main/java/frc/robot/subsystems/Barrel.java
@@ -27,12 +27,13 @@ public class Barrel extends SubsystemBase {
   double m_rollerD = Constants.kBarrelD;
 
   TDNumber m_barrelSpeedRPM;
+  private double m_lastSpeed = 0;
 
   CANSparkMax m_CanSparkMax;
   SparkPIDController m_SparkPIDController;
 
   NoteProximitySensor m_NoteProximitySensor;
-
+  
   /** Creates a new Barrel. */
   private Barrel() {
     super("Barrel");
@@ -67,11 +68,10 @@ public class Barrel extends SubsystemBase {
   }
 
   public void setSpeed(double RPM, boolean backwards) {
-    if (!backwards) {
-      m_SparkPIDController.setReference(RPM, ControlType.kVelocity);
-    }
-    else {
-      m_SparkPIDController.setReference(-RPM, ControlType.kVelocity);
+    double setPoint = backwards? -RPM : RPM;
+    if (m_lastSpeed != setPoint) {
+      m_lastSpeed = setPoint;
+      m_SparkPIDController.setReference(setPoint, ControlType.kVelocity);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/BarrelPivot.java
+++ b/src/main/java/frc/robot/subsystems/BarrelPivot.java
@@ -31,6 +31,7 @@ public class BarrelPivot extends SubsystemBase {
   double   m_angleP = Constants.kBarrelPivotP;
   double   m_angleI = Constants.kBarrelPivotI;
   double   m_angleD = Constants.kBarrelPivotD;
+  private double   m_lastAngle = 0;
   TDNumber m_encoderValueRotations;
   TDNumber m_encoderValueAngleDegrees;
   
@@ -102,8 +103,16 @@ public class BarrelPivot extends SubsystemBase {
   }
 
   public void setTargetAngle(double angle) {
-    m_targetAngle.set(angle % Constants.DEGREES_PER_REVOLUTION);
-    m_SparkPIDController.setReference(m_targetAngle.get(), ControlType.kPosition);
+    double setPoint = angle % Constants.DEGREES_PER_REVOLUTION;
+    setPoint  = MathUtil.clamp(setPoint,
+                               Constants.kBarrelPivotLowerLimitDegrees, 
+                               Constants.kBarrelPivotUpperLimitDegrees);
+    if (setPoint != m_lastAngle)
+    {
+      m_targetAngle.set(setPoint);
+      m_lastAngle = setPoint;
+      m_SparkPIDController.setReference(setPoint, ControlType.kPosition);
+    }
   }
 
   public void resetTargetAngle() {

--- a/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/Elevator.java
@@ -23,6 +23,7 @@ public class Elevator extends SubsystemBase {
   double   m_climbP = Constants.kElevatorPivotP;
   double   m_climbI = Constants.kElevatorPivotI;
   double   m_climbD = Constants.kElevatorPivotD;
+  private double   m_lastSpeed = 0;
 
   CANSparkMax m_LeftCanSparkMax;
   CANSparkMax m_RightCanSparkMax;
@@ -62,11 +63,10 @@ public class Elevator extends SubsystemBase {
   }
 
   public void setSpeed(double RPM, boolean backwards) {
-    if (!backwards) {
-      m_SparkPIDController.setReference(RPM, ControlType.kVelocity);
-    }
-    else {
-      m_SparkPIDController.setReference(-RPM, ControlType.kVelocity);
+    double setPoint = backwards? -RPM : RPM;
+    if (setPoint != m_lastSpeed) {
+      m_lastSpeed = setPoint;
+      m_SparkPIDController.setReference(setPoint, ControlType.kVelocity);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -26,6 +26,7 @@ public class Intake extends SubsystemBase {
   double   m_intakeP = Constants.kIntakeP;
   double   m_intakeI = Constants.kIntakeI;
   double   m_intakeD = Constants.kIntakeD;
+  private double   m_lastSpeed = 0;
   
   CANSparkMax m_ILeftSparkMax;
   CANSparkMax m_IRightSparkMax;
@@ -73,11 +74,10 @@ public class Intake extends SubsystemBase {
   }
 
   public void setSpeeds(double RPM, boolean backwards) {
-    if (!backwards) {
-      m_SparkPIDController.setReference(RPM, ControlType.kVelocity);
-    }
-    else {
-      m_SparkPIDController.setReference(-RPM, ControlType.kVelocity);
+    double setPoint = backwards? -RPM : RPM;
+    if (setPoint != m_lastSpeed) {
+      m_lastSpeed = setPoint;
+      m_SparkPIDController.setReference(setPoint, ControlType.kVelocity);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/MAXSwerveModule.java
+++ b/src/main/java/frc/robot/subsystems/MAXSwerveModule.java
@@ -29,6 +29,8 @@ public class MAXSwerveModule {
 
   private double m_chassisAngularOffset = 0;
   private SwerveModuleState m_desiredState = new SwerveModuleState(0.0, new Rotation2d());
+  private double m_lastAngle = 0;
+  private double m_lastSpeed = 0;
 
   /**
    * Constructs a MAXSwerveModule and configures the driving and turning motor,
@@ -151,8 +153,14 @@ public class MAXSwerveModule {
         new Rotation2d(m_turningEncoder.getPosition()));
 
     // Command driving and turning SPARKS MAX towards their respective setpoints.
-    m_drivingPIDController.setReference(optimizedDesiredState.speedMetersPerSecond, CANSparkMax.ControlType.kVelocity);
-    m_turningPIDController.setReference(optimizedDesiredState.angle.getRadians(), CANSparkMax.ControlType.kPosition);
+    if (optimizedDesiredState.speedMetersPerSecond != m_lastSpeed) {
+      m_lastSpeed = optimizedDesiredState.speedMetersPerSecond;
+      m_drivingPIDController.setReference(optimizedDesiredState.speedMetersPerSecond, CANSparkMax.ControlType.kVelocity);
+    }
+    if (optimizedDesiredState.angle.getRadians() != m_lastAngle) {
+      m_lastAngle = optimizedDesiredState.angle.getRadians();
+      m_turningPIDController.setReference(optimizedDesiredState.angle.getRadians(), CANSparkMax.ControlType.kPosition);
+    }
 
     m_desiredState = desiredState;
   }

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -27,6 +27,8 @@ public class Shooter extends SubsystemBase {
   double   m_shootP = Constants.kShooterP;
   double   m_shootI = Constants.kShooterI;
   double   m_shootD = Constants.kShooterD;
+  private double m_lastLeftSpeed = 0;
+  private double m_lastRightSpeed = 0;
 
   TDNumber m_rightMeasuredSpeed;
   TDNumber m_leftMeasuredSpeed;
@@ -88,17 +90,17 @@ public class Shooter extends SubsystemBase {
   }
 
   public void setSpeeds(double LeftRPM, double RightRPM, boolean backwards) {
-    if (!backwards) {
-      m_leftSpeedSetpoint = LeftRPM;
-      m_rightSpeedSetpoint = RightRPM;
-      m_LeftSparkPIDController.setReference(LeftRPM, ControlType.kVelocity);
-      m_RightSparkPIDController.setReference(RightRPM, ControlType.kVelocity);
+    double leftSetPoint = backwards? -LeftRPM : LeftRPM;
+    double rightSetPoint = backwards? -RightRPM : RightRPM;
+
+    if (leftSetPoint != m_lastLeftSpeed)
+    {
+      m_lastLeftSpeed = leftSetPoint;
+      m_LeftSparkPIDController.setReference(leftSetPoint, ControlType.kVelocity);
     }
-    else {
-      m_leftSpeedSetpoint = -LeftRPM;
-      m_rightSpeedSetpoint = -RightRPM;
-      m_LeftSparkPIDController.setReference(-LeftRPM, ControlType.kVelocity);
-      m_RightSparkPIDController.setReference(-RightRPM, ControlType.kVelocity);
+    if (rightSetPoint != m_lastRightSpeed) {
+      m_lastRightSpeed = rightSetPoint;
+      m_RightSparkPIDController.setReference(rightSetPoint, ControlType.kVelocity);
     }
   }
 
@@ -106,6 +108,8 @@ public class Shooter extends SubsystemBase {
     if (m_SLeftSparkMax != null && m_SRightSparkMax != null) {
       m_SLeftSparkMax.set(leftSpeed);
       m_SRightSparkMax.set(rightSpeed);
+      m_lastLeftSpeed = 0;
+      m_lastRightSpeed = 0;
     }
   }
 
@@ -113,14 +117,16 @@ public class Shooter extends SubsystemBase {
     if (m_SLeftSparkMax != null && m_SRightSparkMax != null) {
       m_SLeftSparkMax.set(-speed);
       m_SRightSparkMax.set(-speed);
-    }
+      m_lastLeftSpeed = 0;
+      m_lastRightSpeed = 0;    }
   }
 
   public void spinStop() {
     if (m_SLeftSparkMax != null && m_SRightSparkMax != null) {
       m_SLeftSparkMax.set(0);
       m_SRightSparkMax.set(0);
-    }
+      m_lastLeftSpeed = 0;
+      m_lastRightSpeed = 0;    }
   }
 
   public boolean isAtSetSpeed() {


### PR DESCRIPTION
The return type of SparkPidController.setReference() is REVLibError, rumored to have memory consumption issues. With this change, subsystems only invoke setReference when the target setpoint changes. Even if REVLibError is not an issue, making fewer calls is beneficial.