### PR TITLE
BarrelPivot and PivotToSpeaker improvements

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -88,6 +88,7 @@ public final class Constants {
     public static final double BP_SPEED = 0.1;
 
     public static final double BP_ANGLE_TOLERANCE_DEGREES = 1;
+    public static final double BP_SPEAKER_TOLERANCE_DEGREES = 0.5;
     public static final double BP_SOURCE_ANGLE_DEGREES = 111;
     public static final double BP_AMP_SCORING_ANGLE_DEGREES = 114;
      public static final double BP_SHOOTER_SCORING_ANGLE_DEGREES = 121;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -66,7 +66,7 @@ public final class Constants {
     public static final double kBarrelD = 0;
 
     public static final Transform3d kRobotToBarrel =
-            new Transform3d(new Translation3d(0.0, -0.5, -0.15), 
+            new Transform3d(new Translation3d(0.0, 0.33, 0.2),
                 new Rotation3d(0, 0, 0));
 
     public static final double BARREL_SPEED = 0.7;
@@ -233,7 +233,7 @@ public final class Constants {
             AprilTagFields.kDefaultField.loadAprilTagLayoutField();
 
     // Height of Speaker mouth above tag pose
-    public static final double SPEAKER_HEIGHT_OFFSET = 0.75;
+    public static final double SPEAKER_HEIGHT_OFFSET = 0.6;
 
     // Determine these Poses on a real field
     public static final Pose2d kSource1RedPose = new Pose2d();

--- a/src/main/java/frc/robot/commands/BarrelPivot/PivotToSpeaker.java
+++ b/src/main/java/frc/robot/commands/BarrelPivot/PivotToSpeaker.java
@@ -61,9 +61,7 @@ public class PivotToSpeaker extends Command {
 
   // Called once the command ends or is interrupted.
   @Override
-  public void end(boolean interrupted) {
-    m_barrelPivot.stopPivot();
-  }
+  public void end(boolean interrupted) {}
 
   // Returns true when the command should end.
   @Override

--- a/src/main/java/frc/robot/subsystems/BarrelPivot.java
+++ b/src/main/java/frc/robot/subsystems/BarrelPivot.java
@@ -137,7 +137,7 @@ public class BarrelPivot extends SubsystemBase {
   }
 
   public boolean atGoal() {
-    return MathUtil.isNear(getTargetAngle(), getAngle(), Constants.BP_ANGLE_TOLERANCE_DEGREES);
+    return MathUtil.isNear(getTargetAngle(), getAngle(), Constants.BP_SPEAKER_TOLERANCE_DEGREES);
   }
 
   public void pivotUpwards() {


### PR DESCRIPTION
- added new constant, BP_SPEAKER_TOLERANCE_DEGREES, specific to PivotToSpeaker for better accuracy when aiming
- removed stopPivot() in the end() override on PivotToSpeaker
- implemented updated measurements to constants for BarrelPivot & speaker (kRobotToBarrel, SPEAKER_HEIGHT_OFFSET)