### PR TITLE
updates BarrelPivot alignment commands

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -87,7 +87,7 @@ public final class Constants {
 
     public static final double BP_SPEED = 0.1;
 
-    public static final double BP_ANGLE_TOLERANCE_DEGREES = 1;
+    public static final double BP_ANGLE_TOLERANCE_DEGREES = 3;
     public static final double BP_SPEAKER_TOLERANCE_DEGREES = 0.5;
     public static final double BP_SOURCE_ANGLE_DEGREES = 111;
     public static final double BP_AMP_SCORING_ANGLE_DEGREES = 114;

--- a/src/main/java/frc/robot/commands/BarrelPivot/AlignPivotToAmp.java
+++ b/src/main/java/frc/robot/commands/BarrelPivot/AlignPivotToAmp.java
@@ -38,6 +38,6 @@ public class AlignPivotToAmp extends Command {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return m_barrelPivot.alignedToAmp();
+    return false;
   }
 }

--- a/src/main/java/frc/robot/commands/BarrelPivot/AlignPivotToSpeakerClose.java
+++ b/src/main/java/frc/robot/commands/BarrelPivot/AlignPivotToSpeakerClose.java
@@ -6,7 +6,6 @@ package frc.robot.commands.BarrelPivot;
 
 import frc.robot.testingdashboard.Command;
 import frc.robot.testingdashboard.TDNumber;
-import edu.wpi.first.math.MathUtil;
 import frc.robot.Constants;
 import frc.robot.subsystems.BarrelPivot;
 
@@ -39,6 +38,6 @@ public class AlignPivotToSpeakerClose extends Command {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return MathUtil.isNear(Constants.BP_SHOOTER_SCORING_ANGLE_DEGREES, m_barrelPivot.getAngle(), 3);
+    return false;
   }
 }

--- a/src/main/java/frc/robot/commands/BarrelPivot/AlignWithSource.java
+++ b/src/main/java/frc/robot/commands/BarrelPivot/AlignWithSource.java
@@ -38,6 +38,6 @@ public class AlignWithSource extends Command {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return m_barrelPivot.alignedToSource();
+    return false;
   }
 }

--- a/src/main/java/frc/robot/commands/PrepareToAmp.java
+++ b/src/main/java/frc/robot/commands/PrepareToAmp.java
@@ -10,6 +10,7 @@ import frc.robot.commands.BarrelPivot.AlignPivotToAmp;
 import frc.robot.commands.Lights.BlinkLights;
 import frc.robot.commands.Lights.MoveLightsGreen;
 import frc.robot.subsystems.AmpAddOn;
+import frc.robot.subsystems.BarrelPivot;
 import frc.robot.subsystems.SensorMonitor;
 import frc.robot.subsystems.SensorMonitor.NoteLocation;
 
@@ -29,6 +30,7 @@ public class PrepareToAmp extends Command {
   AlignPivotToAmp m_alignPivotToAmp;
   MoveLightsGreen m_MoveLightsGreen;
 
+  BarrelPivot m_barrelPivot;
   SensorMonitor m_sensorMonitor;
 
   private boolean m_isFinished;
@@ -47,6 +49,7 @@ public class PrepareToAmp extends Command {
     m_alignPivotToAmp = new AlignPivotToAmp();
     m_MoveLightsGreen = new MoveLightsGreen();
 
+    m_barrelPivot = BarrelPivot.getInstance();
     m_sensorMonitor = SensorMonitor.getInstance();
   }
 
@@ -91,7 +94,7 @@ public class PrepareToAmp extends Command {
         break;
 
       case WAIT_FOR_ALIGN_PIVOTS:
-        if (m_ampPivotToScoringPosition.isFinished() && m_alignPivotToAmp.isFinished()) {
+        if (m_ampPivotToScoringPosition.isFinished() && m_barrelPivot.alignedToAmp()) {
           m_blinkLights.cancel();
           m_MoveLightsGreen.schedule();
           m_state = State.READY_TO_AMP_SCORE;

--- a/src/main/java/frc/robot/commands/PrepareToShoot.java
+++ b/src/main/java/frc/robot/commands/PrepareToShoot.java
@@ -123,6 +123,14 @@ public class PrepareToShoot extends Command {
         if (m_sensorMonitor.determineLocation() == NoteLocation.c_NoNote) {
           m_state = State.DONE;
         }
+        if (!m_barrelPivot.atGoal() && m_moveLightsGreen.isScheduled()) {
+          m_moveLightsGreen.cancel();
+          m_blinkLights.schedule();
+        }
+        else if (m_barrelPivot.atGoal() && m_blinkLights.isScheduled()) {
+          m_blinkLights.cancel();
+          m_moveLightsGreen.schedule();
+        }
         // TODO: 
         // if ((speaker not tracked || BP not aligned) && red not scheduled)
         //   schedule red lights

--- a/src/main/java/frc/robot/commands/SourceIntake.java
+++ b/src/main/java/frc/robot/commands/SourceIntake.java
@@ -11,6 +11,7 @@ import frc.robot.commands.BarrelPivot.AlignWithSource;
 import frc.robot.commands.Lights.BlinkLights;
 import frc.robot.commands.Lights.MoveLightsGreen;
 import frc.robot.commands.Shooter.IntakeFromShooter;
+import frc.robot.subsystems.BarrelPivot;
 import frc.robot.subsystems.SensorMonitor;
 import frc.robot.subsystems.SensorMonitor.NoteLocation;
 import frc.robot.subsystems.Shooter;
@@ -33,6 +34,7 @@ public class SourceIntake extends Command {
   IntakeFromShooter m_intakeFromShooter;
   SpinBarrelBackward m_spinBarrelBackward;
 
+  BarrelPivot m_barrelPivot;
   SensorMonitor m_sensorMonitor;
 
   private boolean m_isFinished;
@@ -89,7 +91,7 @@ public class SourceIntake extends Command {
         break;
 
       case ALIGN_PIVOTS:
-        if (m_ampPivotToIntake.isFinished() && m_alignWithSource.isFinished()) {
+        if (m_ampPivotToIntake.isFinished() && m_barrelPivot.alignedToSource()) {
           m_state = State.SPIN_SUBSYSTEMS_IN;
         }
         break;

--- a/src/main/java/frc/robot/subsystems/BarrelPivot.java
+++ b/src/main/java/frc/robot/subsystems/BarrelPivot.java
@@ -136,6 +136,10 @@ public class BarrelPivot extends SubsystemBase {
     return MathUtil.isNear(Constants.BP_AMP_SCORING_ANGLE_DEGREES, m_barrelPivot.getAngle(), Constants.BP_ANGLE_TOLERANCE_DEGREES);
   }
 
+  public boolean alignedToShootClose() {
+    return MathUtil.isNear(Constants.BP_SHOOTER_SCORING_ANGLE_DEGREES, m_barrelPivot.getAngle(), Constants.BP_ANGLE_TOLERANCE_DEGREES);
+  }
+
   public boolean atGoal() {
     return MathUtil.isNear(getTargetAngle(), getAngle(), Constants.BP_SPEAKER_TOLERANCE_DEGREES);
   }


### PR DESCRIPTION
This commit updates the BarrelPivot alignment commands and how they are used in the state machines, so that PivotDOWNDOWNDOWN will not prematurely take control of the pivot if that down command is set as the default command.