### PR TITLE
adds Consume to autos to prevent note ripping

### DIFF
--- a/src/main/deploy/pathplanner/autos/botMiddle.auto
+++ b/src/main/deploy/pathplanner/autos/botMiddle.auto
@@ -141,6 +141,12 @@
                                               "data": {
                                                 "name": "SpinBarrelForward"
                                               }
+                                            },
+                                            {
+                                              "type": "named",
+                                              "data": {
+                                                "name": "Consume"
+                                              }
                                             }
                                           ]
                                         }

--- a/src/main/deploy/pathplanner/autos/topMiddle.auto
+++ b/src/main/deploy/pathplanner/autos/topMiddle.auto
@@ -147,6 +147,12 @@
                                               "data": {
                                                 "name": "SpinBarrelForward"
                                               }
+                                            },
+                                            {
+                                              "type": "named",
+                                              "data": {
+                                                "name": "Consume"
+                                              }
                                             }
                                           ]
                                         }
@@ -235,6 +241,12 @@
                                               "type": "named",
                                               "data": {
                                                 "name": "SpinBarrelForward"
+                                              }
+                                            },
+                                            {
+                                              "type": "named",
+                                              "data": {
+                                                "name": "Consume"
                                               }
                                             }
                                           ]


### PR DESCRIPTION
This commit adds the Consume command in parallel with SpinBarrelForward for the two middle note autos. This is to avoid a situation of the note being stuck in the Intake while being pulled by the Barrel.