### PR TITLE
Sensor rework, Ground Intake, and Operator Control Remapping

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -91,7 +91,7 @@ public final class Constants {
     public static final double BP_ANGLE_OFFSET_TO_HORIZONTAL_DEGREES = 70;
     public static final double BP_ANGLE_TOLERANCE_DEGREES = 3;
     public static final double BP_SPEAKER_TOLERANCE_DEGREES = 0.5;
-    public static final double BP_SOURCE_ANGLE_DEGREES = 111;
+    public static final double BP_SOURCE_ANGLE_DEGREES = 108;
     public static final double BP_AMP_SCORING_ANGLE_DEGREES = 100;
     public static final double BP_SHOOTER_SCORING_ANGLE_DEGREES = 120.7;
     public static final double BP_DOWN_ANGLE_DEGREES = 81;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -145,7 +145,9 @@ public final class Constants {
     public static final double kFreeSpeedRpm = 5676;
 
     //Sensor Constants
-    public static final int kSensorDebounceCycles = 10;
+    public static final boolean kSensorThreadingEnabled = true;
+    public static final int kSensorDebounceCycles = 3;
+    public static final int kThreadedSensorDebounceCycles = 10;
     public static final double kConfusedSensorTimeoutSeconds = 1.5;
 
     // Defines Swerve Module constants

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -145,7 +145,7 @@ public final class Constants {
     public static final double kFreeSpeedRpm = 5676;
 
     //Sensor Constants
-    public static final int kSensorDebounceCycles = 3;
+    public static final int kSensorDebounceCycles = 10;
     public static final double kConfusedSensorTimeoutSeconds = 1.5;
 
     // Defines Swerve Module constants

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -15,8 +15,10 @@ import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.XboxController.Button;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.commands.Sensors.ResetAllSensors;
 import frc.robot.commands.Sensors.ToggleSensorsOnOff;
 import frc.robot.subsystems.Drive;
@@ -86,32 +88,29 @@ public class OI {
 
     // Driver Mapping
     new JoystickButton(m_DriverXboxController, Button.kRightBumper.value).whileTrue(new PrepareToShoot());
-    new JoystickButton(m_DriverXboxController, Button.kLeftBumper.value).whileTrue(new PrepareToShootClose());
     new JoystickButton(m_DriverXboxController, Button.kBack.value).onTrue(new InstantCommand(()->Drive.getInstance().zeroHeading()));
     
     // Drive to locations on the field
-    // new JoystickButton(m_DriverXboxController, Button.kA.value).onTrue(new DriveToPose(()->{
-    //   Pose2d ampPose = FieldUtils.getInstance().getAmpPose().toPose2d();
-    //   return new Pose2d(ampPose.getX(), ampPose.getY(), new Rotation2d(Units.degreesToRadians(90)));
-    // }));
-    // new JoystickButton(m_DriverXboxController, Button.kA.value).whileTrue(new DriveToPose(FieldUtils.getInstance()::getAmpScorePose));
+    new JoystickButton(m_DriverXboxController, Button.kA.value).whileTrue(new DriveToPose(FieldUtils.getInstance()::getAmpScorePose));
     // new JoystickButton(m_DriverXboxController, Button.kX.value).whileTrue(new DriveToPose(FieldUtils.getInstance()::getSource1Pose));
     // new JoystickButton(m_DriverXboxController, Button.kB.value).whileTrue(new DriveToPose(FieldUtils.getInstance()::getSource3Pose));
     // new JoystickButton(m_DriverXboxController, Button.kY.value).whileTrue(new DriveToPose(FieldUtils.getInstance()::getSpeakerScorePose));
 
     // Operator Mapping
-    new JoystickButton(m_OperatorXboxController, Button.kA.value).whileTrue(new PrepareToAmp());
     new JoystickButton(m_OperatorXboxController, Button.kB.value).whileTrue(new SourceIntake());
-    new JoystickButton(m_OperatorXboxController, Button.kX.value).whileTrue(new MoveNoteForward());
-    // new JoystickButton(m_OperatorXboxController, Button.kX.value).whileTrue(new GroundIntake());
+    new JoystickButton(m_OperatorXboxController, Button.kA.value).whileTrue(new MoveNoteForward());
+    new JoystickButton(m_OperatorXboxController, Button.kX.value).whileTrue(new GroundIntake());
     new JoystickButton(m_OperatorXboxController, Button.kY.value).whileTrue(new MoveNoteBackward());
-    new JoystickButton(m_OperatorXboxController, Button.kLeftBumper.value).whileTrue(new ScoreAmp());
-    new JoystickButton(m_OperatorXboxController, Button.kRightBumper.value).whileTrue(new ShootSpeaker());
+
     new JoystickButton(m_OperatorXboxController, Button.kBack.value).whileTrue(new AmpPivotToIntake());
     new JoystickButton(m_OperatorXboxController, Button.kStart.value).whileTrue(new PivotDOWNDOWNDOWN());
     new JoystickButton(m_OperatorXboxController, Button.kStart.value).whileTrue(new AmpPivotToIntake());
-    // new JoystickButton(m_OperatorXboxController, Button.kBack.value).onTrue(new ToggleSensorsOnOff());
-    // new JoystickButton(m_OperatorXboxController, Button.kStart.value).onTrue(new ResetAllSensors());
+
+    new JoystickButton(m_OperatorXboxController, Button.kRightBumper.value).whileTrue(new PrepareToShootClose());
+    new Trigger(()->{return (m_OperatorXboxController.getRightTriggerAxis() > 0.5);}).whileTrue(new ShootSpeaker());
+
+    new JoystickButton(m_OperatorXboxController, Button.kLeftBumper.value).whileTrue(new PrepareToAmp());
+    new Trigger(()->{return (m_OperatorXboxController.getLeftTriggerAxis() > 0.5);}).whileTrue(new ScoreAmp());
   }
 
   /**

--- a/src/main/java/frc/robot/commands/MoveNoteToAmp.java
+++ b/src/main/java/frc/robot/commands/MoveNoteToAmp.java
@@ -20,6 +20,8 @@ public class MoveNoteToAmp extends Command {
   private Barrel m_barrel;
   private Intake m_intake;
 
+  private SensorMonitor m_sensorMonitor;
+
   private ParallelRaceGroup m_BlinkLights;
 
   private boolean m_finished;
@@ -47,6 +49,8 @@ public class MoveNoteToAmp extends Command {
     m_barrel = Barrel.getInstance();
     m_intake = Intake.getInstance();
 
+    m_sensorMonitor = SensorMonitor.getInstance();
+
     m_BlinkLights = new BlinkLights().withTimeout(1.5);
 
     // Use addRequirements() here to declare subsystem dependencies.
@@ -57,9 +61,9 @@ public class MoveNoteToAmp extends Command {
   @Override
   public void initialize() {
     m_finished = false;
-    if(m_amp.noteCenteredOnSensor()){
+    if(m_sensorMonitor.ampNoteCentered()){
       m_state = State.c_state_Done;
-    } else if(m_shooter.hasNote() && !m_amp.pivotAtIntake() ){
+    } else if(m_sensorMonitor.shooterHasNote() && !m_amp.pivotAtIntake() ){
       m_state = State.c_state_startsInShooter;
     } else if (!m_amp.pivotAtIntake()) {
       m_state = State.c_state_moveAmpToIntake;
@@ -79,7 +83,7 @@ public class MoveNoteToAmp extends Command {
         m_barrel.setSpeed(Constants.BARREL_SPEED_RPM, true);
         m_shooter.setSpeeds(Constants.SHOOTER_INTAKING_SPEED_RPM, Constants.SHOOTER_INTAKING_SPEED_RPM, true);
 
-        if(!m_shooter.hasNote() && m_barrel.noteCenteredOnSensor()) {
+        if(!m_sensorMonitor.shooterHasNote() && m_sensorMonitor.barrelNoteCentered()) {
           m_barrel.spinStop();
           m_shooter.spinStop();
           nextState = State.c_state_moveAmpToIntake;
@@ -102,7 +106,7 @@ public class MoveNoteToAmp extends Command {
         m_intake.setSpeeds(Constants.INTAKE_SPEED_RPM, false);
         m_barrel.setSpeed(Constants.BARREL_SPEED_RPM, false);
 
-        if(m_barrel.noteCenteredOnSensor() && !m_intake.hasNote()){
+        if(m_sensorMonitor.barrelNoteCentered() && !m_sensorMonitor.intakeHasNote()){
           m_intake.spinStop();
           nextState = State.c_state_inBarrel;
         } else {
@@ -115,7 +119,7 @@ public class MoveNoteToAmp extends Command {
         m_shooter.setSpeeds(Constants.SHOOTER_INTAKING_SPEED_RPM, Constants.SHOOTER_INTAKING_SPEED_RPM, false);
         m_amp.setSpeed(Constants.AMP_SPEED_RPM, false);
 
-        if(!m_barrel.hasNote()){
+        if(!m_sensorMonitor.barrelHasNote()){
           m_intake.spinStop();
           nextState = State.c_state_inShooter;
         } else {
@@ -128,7 +132,7 @@ public class MoveNoteToAmp extends Command {
         m_shooter.setSpeeds(Constants.SHOOTER_INTAKING_SPEED_RPM, Constants.SHOOTER_INTAKING_SPEED_RPM, false);
         m_barrel.setSpeed(Constants.BARREL_SPEED_RPM, false);
 
-        if(!m_shooter.hasNote() && m_amp.hasNote()){
+        if(!m_sensorMonitor.shooterHasNote() && m_sensorMonitor.ampHasNote()){
           m_barrel.spinStop();
           nextState = State.c_state_inAmp;
         } else {
@@ -140,7 +144,7 @@ public class MoveNoteToAmp extends Command {
         m_amp.setSpeed(Constants.AMP_SPEED_RPM, false);
         m_shooter.setSpeeds(Constants.SHOOTER_INTAKING_SPEED_RPM, Constants.SHOOTER_INTAKING_SPEED_RPM, false);
 
-        if(m_amp.noteCenteredOnSensor()) {
+        if(m_sensorMonitor.ampNoteCentered()) {
           m_amp.spinStop();
           m_shooter.spinStop();
           nextState = State.c_state_Done;
@@ -208,7 +212,7 @@ public class MoveNoteToAmp extends Command {
         return State.c_state_inShooter;
 
       case c_Amp:
-        if(m_amp.noteCenteredOnSensor()) {
+        if(m_sensorMonitor.ampNoteCentered()) {
           return State.c_state_Done;
         } else {
           return State.c_state_inAmp;

--- a/src/main/java/frc/robot/commands/MoveNoteToBarrel.java
+++ b/src/main/java/frc/robot/commands/MoveNoteToBarrel.java
@@ -20,6 +20,8 @@ public class MoveNoteToBarrel extends Command {
   private Barrel m_barrel;
   private Intake m_intake;
 
+  private SensorMonitor m_sensorMonitor;
+
   private ParallelRaceGroup m_BlinkLights;
 
   private State m_state;
@@ -31,6 +33,8 @@ public class MoveNoteToBarrel extends Command {
     m_shooter = Shooter.getInstance();
     m_barrel = Barrel.getInstance();
     m_intake = Intake.getInstance();
+
+    m_sensorMonitor = SensorMonitor.getInstance();
 
     m_BlinkLights = new BlinkLights().withTimeout(Constants.kConfusedSensorTimeoutSeconds);
 
@@ -61,7 +65,7 @@ public class MoveNoteToBarrel extends Command {
     switch (m_state) {
       case c_state_prepAmp:
         //Ensure note is out of the way, pivot amp down to intake
-        if(!m_amp.noteCenteredOnSensor()){
+        if(!m_sensorMonitor.ampNoteCentered()){
           m_amp.setSpeed(Constants.AMP_SPEED_RPM, false);
         } else {
           m_amp.spinStop();
@@ -80,7 +84,7 @@ public class MoveNoteToBarrel extends Command {
         m_amp.setSpeed(Constants.AMP_SPEED_RPM, true);
         m_shooter.setSpeeds(Constants.SHOOTER_INTAKING_SPEED_RPM, Constants.SHOOTER_INTAKING_SPEED_RPM, true);
         
-        if(m_shooter.hasNote()){
+        if(m_sensorMonitor.shooterHasNote()){
           nextState = State.c_state_inShooter;
         } else {
           nextState = State.c_state_inAmp;
@@ -91,7 +95,7 @@ public class MoveNoteToBarrel extends Command {
         m_shooter.setSpeeds(Constants.SHOOTER_INTAKING_SPEED_RPM, Constants.SHOOTER_INTAKING_SPEED_RPM, true);
         m_barrel.setSpeed(Constants.BARREL_SPEED_RPM, true);
         m_amp.setSpeed(Constants.AMP_SPEED_RPM, true);
-        if(m_barrel.noteCenteredOnSensor() && !m_shooter.hasNote()) {
+        if(m_sensorMonitor.barrelNoteCentered() && !m_sensorMonitor.shooterHasNote()) {
           nextState = State.c_state_Done;
         } else {
           nextState = State.c_state_inShooter;
@@ -101,7 +105,7 @@ public class MoveNoteToBarrel extends Command {
       case c_state_inIntake:
         m_intake.setSpeeds(Constants.INTAKE_SPEED_RPM, false);
         m_barrel.setSpeed(Constants.BARREL_SPEED_RPM, false);
-        if(m_barrel.noteCenteredOnSensor() && !m_intake.hasNote()){
+        if(m_sensorMonitor.barrelNoteCentered() && !m_sensorMonitor.intakeHasNote()){
           nextState = State.c_state_Done;
         } else {
           nextState = State.c_state_inIntake;

--- a/src/main/java/frc/robot/subsystems/AmpAddOn.java
+++ b/src/main/java/frc/robot/subsystems/AmpAddOn.java
@@ -50,7 +50,6 @@ public class AmpAddOn extends SubsystemBase {
   SparkPIDController m_PivotSparkPIDController;
   AbsoluteEncoder m_absoluteEncoder;
 
-  NoteProximitySensor m_NoteProximitySensor;
   // initially set motor to "Don't move"
   private double m_lastAngle = 0;
   private double m_lastSpeed = 0;
@@ -103,7 +102,6 @@ public class AmpAddOn extends SubsystemBase {
     m_encoderValueAngleDegrees = new TDNumber(this, "Encoder Values", "Angle (degrees)", getAngle());
     m_rollerSpeedRPM = new TDNumber(this, "Encoder Values", "Measured Roller Speed RPM");
 
-    m_NoteProximitySensor = new NoteProximitySensor(RobotMap.A_NOTE_SENSOR, this);
   }
 
   public static AmpAddOn getInstance() {
@@ -200,27 +198,6 @@ public class AmpAddOn extends SubsystemBase {
     return MathUtil.isNear(Constants.kAPivotDeliverAmpPositionDegrees, getAngle(), Constants.kAPivotToleranceDegrees);
   }
 
-  public boolean hasNote() {
-    if(m_NoteProximitySensor != null){
-      return m_NoteProximitySensor.hasNote();
-    } else {
-      return false;
-    }
-  }
-
-  public boolean noteCenteredOnSensor() {
-    if(m_NoteProximitySensor != null) {
-      return m_NoteProximitySensor.noteIsCentered();
-    } else {
-      return false;
-    }
-  }
-
-  public void resetSensor() {
-    if(m_NoteProximitySensor != null) {
-      m_NoteProximitySensor.reset();
-    }
-  }
 
   @Override
   public void periodic() {
@@ -264,8 +241,5 @@ public class AmpAddOn extends SubsystemBase {
       m_rollerSpeedRPM.set(m_CanSparkMax.getEncoder().getVelocity());
     }
     super.periodic();
-    if(m_NoteProximitySensor != null) {
-      m_NoteProximitySensor.update();
-    }
   }
 }

--- a/src/main/java/frc/robot/subsystems/Barrel.java
+++ b/src/main/java/frc/robot/subsystems/Barrel.java
@@ -32,8 +32,6 @@ public class Barrel extends SubsystemBase {
   CANSparkMax m_CanSparkMax;
   SparkPIDController m_SparkPIDController;
 
-  NoteProximitySensor m_NoteProximitySensor;
-
   /** Creates a new Barrel. */
   private Barrel() {
     super("Barrel");
@@ -56,7 +54,6 @@ public class Barrel extends SubsystemBase {
       m_SparkPIDController.setI(m_rollerI);
       m_SparkPIDController.setD(m_rollerD);
 
-      m_NoteProximitySensor = new NoteProximitySensor(RobotMap.B_NOTE_SENSOR, this);
     }
   }
 
@@ -101,27 +98,6 @@ public class Barrel extends SubsystemBase {
     m_CanSparkMax.setIdleMode(IdleMode.kBrake);
   }
 
-  public boolean hasNote() {
-    if(m_NoteProximitySensor != null) {
-      return m_NoteProximitySensor.hasNote();
-    } else {
-      return false;
-    }
-  }
-
-  public boolean noteCenteredOnSensor() {
-    if(m_NoteProximitySensor != null) {
-      return m_NoteProximitySensor.noteIsCentered();  
-    } else {
-      return false;
-    }
-  }
-
-  public void resetSensor() {
-    if(m_NoteProximitySensor != null) {
-      m_NoteProximitySensor.reset();
-    }
-  }
 
   @Override
   public void periodic() {
@@ -149,8 +125,5 @@ public class Barrel extends SubsystemBase {
     m_barrelSpeedRPM.set(m_CanSparkMax.getEncoder().getVelocity());
 
     super.periodic();
-    if(m_NoteProximitySensor != null){
-      m_NoteProximitySensor.update();
-    }
   }
 }

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -32,7 +32,6 @@ public class Intake extends SubsystemBase {
   CANSparkMax m_IRightSparkMax;
   SparkPIDController m_SparkPIDController;
 
-  NoteProximitySensor m_NoteProximitySensor;
 
   /** Creates a new Intake. */
   private Intake() {
@@ -62,7 +61,6 @@ public class Intake extends SubsystemBase {
       m_SparkPIDController.setI(m_intakeI);
       m_SparkPIDController.setD(m_intakeD);
 
-      m_NoteProximitySensor = new NoteProximitySensor(RobotMap.I_NOTE_SENSOR, this);
     }
   }
 
@@ -96,28 +94,6 @@ public class Intake extends SubsystemBase {
       m_ILeftSparkMax.set(0);
   }
 
-  public boolean hasNote() {
-    if(m_NoteProximitySensor != null) {
-      return m_NoteProximitySensor.hasNote();
-    } else {
-      return false;
-    }
-  }
-
-  public boolean noteCenteredOnSensor() {
-    if(m_NoteProximitySensor != null) {
-      return m_NoteProximitySensor.noteIsCentered();
-    } else {
-      return false;
-    }
-  }
-
-  public void resetSensor() {
-    if(m_NoteProximitySensor != null) {
-      m_NoteProximitySensor.reset();
-    }
-  }
-
   @Override
   public void periodic() {
     if (Constants.kEnableIntakePIDTuning && 
@@ -143,8 +119,5 @@ public class Intake extends SubsystemBase {
     }
       
     super.periodic();
-    if(m_NoteProximitySensor != null) {
-      m_NoteProximitySensor.update();
-    }
   }
 }

--- a/src/main/java/frc/robot/subsystems/SensorMonitor.java
+++ b/src/main/java/frc/robot/subsystems/SensorMonitor.java
@@ -56,7 +56,7 @@ public class SensorMonitor extends SubsystemBase {
 
     m_noteLocation = new TDString(this, "", "Note Location", "No Note In Robot");
     m_sensorsEnabled = new TDBoolean(this, "Toggle Sensors", "Sensors Enabled", false);
-    if(Constants.kSensorThreadingEnabled && m_sensorsEnabled.get()){
+    if(Constants.kSensorThreadingEnabled){
       startSensorThread();
     }
   }
@@ -73,18 +73,6 @@ public class SensorMonitor extends SubsystemBase {
   /** Flips the value of sensorsEnabled boolean */
   public void toggleSensorsOnOff() {
     m_sensorsEnabled.set(!m_sensorsEnabled.get());
-
-    if(Constants.kSensorThreadingEnabled){
-      if(m_sensorsEnabled.get()){
-        startSensorThread();
-      } else {
-        if(m_sensorUpdater != null 
-            && m_sensorUpdater.isAlive()){
-          m_sensorUpdater.interrupt();
-          m_sensorUpdater = null;
-        }
-      }
-    }
   }
 
   public boolean intakeHasNote() {
@@ -155,6 +143,10 @@ public class SensorMonitor extends SubsystemBase {
 
   public boolean barrelNoteCentered() {
     return m_barrel.noteIsCentered();
+  }
+
+  public boolean barrelSeesNote() {
+    return m_barrel.seesNote();
   }
 
   public void barrelResetSensor() {

--- a/src/main/java/frc/robot/subsystems/SensorMonitor.java
+++ b/src/main/java/frc/robot/subsystems/SensorMonitor.java
@@ -5,6 +5,7 @@
 package frc.robot.subsystems;
 
 
+import frc.robot.Constants;
 import frc.robot.RobotMap;
 import frc.robot.testingdashboard.SubsystemBase;
 import frc.robot.testingdashboard.TDBoolean;
@@ -55,7 +56,7 @@ public class SensorMonitor extends SubsystemBase {
 
     m_noteLocation = new TDString(this, "", "Note Location", "No Note In Robot");
     m_sensorsEnabled = new TDBoolean(this, "Toggle Sensors", "Sensors Enabled", false);
-    if(m_sensorsEnabled.get()){
+    if(Constants.kSensorThreadingEnabled && m_sensorsEnabled.get()){
       startSensorThread();
     }
   }
@@ -73,13 +74,15 @@ public class SensorMonitor extends SubsystemBase {
   public void toggleSensorsOnOff() {
     m_sensorsEnabled.set(!m_sensorsEnabled.get());
 
-    if(m_sensorsEnabled.get()){
-      startSensorThread();
-    } else {
-      if(m_sensorUpdater != null 
-          && m_sensorUpdater.isAlive()){
-        m_sensorUpdater.interrupt();
-        m_sensorUpdater = null;
+    if(Constants.kSensorThreadingEnabled){
+      if(m_sensorsEnabled.get()){
+        startSensorThread();
+      } else {
+        if(m_sensorUpdater != null 
+            && m_sensorUpdater.isAlive()){
+          m_sensorUpdater.interrupt();
+          m_sensorUpdater = null;
+        }
       }
     }
   }
@@ -180,6 +183,13 @@ public class SensorMonitor extends SubsystemBase {
 
   @Override
   public void periodic() {
+    if(!Constants.kSensorThreadingEnabled){
+      m_intake.update();
+      m_barrel.update();
+      m_shooter.update();
+      m_amp.update();
+    }
+
     NoteLocation currentLocation = determineLocation();
     m_noteLocation.set(locationToString(currentLocation));
 

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -38,7 +38,6 @@ public class Shooter extends SubsystemBase {
   SparkPIDController m_LeftSparkPIDController;
   SparkPIDController m_RightSparkPIDController;
 
-  NoteProximitySensor m_NoteProximitySensor;
 
   private double m_leftSpeedSetpoint;
   private double m_rightSpeedSetpoint;
@@ -78,7 +77,6 @@ public class Shooter extends SubsystemBase {
       m_RightSparkPIDController.setI(m_shootI);
       m_RightSparkPIDController.setD(m_shootD);
 
-      m_NoteProximitySensor = new NoteProximitySensor(RobotMap.S_NOTE_SENSOR, this);
     }
   }
 
@@ -139,27 +137,6 @@ public class Shooter extends SubsystemBase {
     }
   }
 
-  public boolean hasNote() {
-    if(m_NoteProximitySensor != null) {
-      return m_NoteProximitySensor.hasNote();
-    } else {
-      return false;
-    }
-  }
-
-  public boolean noteCenteredOnSensor() {
-    if(m_NoteProximitySensor != null) {
-      return m_NoteProximitySensor.noteIsCentered();
-    } else {
-      return false;
-    }
-  }
-
-  public void resetSensor() {
-    if(m_NoteProximitySensor != null) {
-      m_NoteProximitySensor.reset();
-    }
-  }
 
   @Override
   public void periodic() {
@@ -191,8 +168,5 @@ public class Shooter extends SubsystemBase {
     m_rightMeasuredSpeed.set(m_SRightSparkMax.getEncoder().getVelocity());
 
     super.periodic();
-    if(m_NoteProximitySensor != null) {
-      m_NoteProximitySensor.update();
-    }
   }
 }

--- a/src/main/java/frc/robot/utils/DebouncedDioSensor.java
+++ b/src/main/java/frc/robot/utils/DebouncedDioSensor.java
@@ -27,6 +27,7 @@ public class DebouncedDioSensor {
     }
 
     public void update() {
+        synchronized(this) {
         boolean val = !m_sensorDio.get();
         if(RobotBase.isSimulation()){
             val = m_testingVal.get() != 0;
@@ -43,10 +44,13 @@ public class DebouncedDioSensor {
             m_output = val;
             resetDebounce();
         }
+        }
     }
 
     public boolean get() {
-        return m_output;
+        synchronized(this){
+            return m_output;
+        }
     }
 
     private void resetDebounce() {

--- a/src/main/java/frc/robot/utils/DebouncedDioSensor.java
+++ b/src/main/java/frc/robot/utils/DebouncedDioSensor.java
@@ -62,7 +62,7 @@ public class DebouncedDioSensor {
     }
 
     private boolean debounceComplete() {
-        return m_debounceIncrementer.get() >= Constants.kSensorDebounceCycles;
+        return m_debounceIncrementer.get() >= (Constants.kSensorThreadingEnabled?Constants.kThreadedSensorDebounceCycles:Constants.kSensorDebounceCycles);
     }
 
 }

--- a/src/main/java/frc/robot/utils/NoteProximitySensor.java
+++ b/src/main/java/frc/robot/utils/NoteProximitySensor.java
@@ -32,52 +32,60 @@ public class NoteProximitySensor {
         boolean val = m_sensor.get();
         State nextState = State.c_State_No_Note;
 
-        switch (m_state) {
-            case c_State_No_Note:
-                nextState = State.c_State_No_Note;
-                if(val){
-                    nextState = State.c_State_First_Leg;
-                }
-                break;
-
-            case c_State_First_Leg:
-                nextState = State.c_State_First_Leg;
-                if(!val){
-                    nextState = State.c_State_Middle_Hole;
-                }
-                break;
-
-            case c_State_Middle_Hole:
-                nextState = State.c_State_Middle_Hole;
-                if(val){
-                    nextState = State.c_State_Second_Leg;
-                }
-                break;
-
-            case c_State_Second_Leg:
-                nextState = State.c_State_Second_Leg;
-                if(!val){
+        synchronized(this) {
+            switch (m_state) {
+                case c_State_No_Note:
                     nextState = State.c_State_No_Note;
-                }
-                break;
+                    if(val){
+                        nextState = State.c_State_First_Leg;
+                    }
+                    break;
 
-            default:
-                System.out.println("Note Proximity Sensor has invalid state");
-                nextState = State.c_State_No_Note;
-                break;
+                case c_State_First_Leg:
+                    nextState = State.c_State_First_Leg;
+                    if(!val){
+                        nextState = State.c_State_Middle_Hole;
+                    }
+                    break;
+
+                case c_State_Middle_Hole:
+                    nextState = State.c_State_Middle_Hole;
+                    if(val){
+                        nextState = State.c_State_Second_Leg;
+                    }
+                    break;
+
+                case c_State_Second_Leg:
+                    nextState = State.c_State_Second_Leg;
+                    if(!val){
+                        nextState = State.c_State_No_Note;
+                    }
+                    break;
+
+                default:
+                    System.out.println("Note Proximity Sensor has invalid state");
+                    nextState = State.c_State_No_Note;
+                    break;
+            }
+
+            m_state = nextState;
         }
-
-        m_state = nextState;
         updateTD();
     }
 
     public boolean hasNote() {
-        return m_state != State.c_State_No_Note;
+        synchronized(this){
+            return m_state != State.c_State_No_Note;
+        }
     }
 
-    public boolean noteIsCentered() { return m_state == State.c_State_Middle_Hole; }
+    public boolean seesNote() {
+        return m_sensor.get();
+    }
 
-    public void reset() { m_state = State.c_State_No_Note; }
+    public boolean noteIsCentered() { synchronized(this){return m_state == State.c_State_Middle_Hole;} }
+
+    public void reset() { synchronized(this){ m_state = State.c_State_No_Note;} }
 
     public void updateTD(){
         switch (m_state) {

--- a/src/main/java/frc/robot/utils/SensorThread.java
+++ b/src/main/java/frc/robot/utils/SensorThread.java
@@ -1,0 +1,29 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.utils;
+
+/** Add your docs here. */
+public class SensorThread extends Thread 
+{
+    private NoteProximitySensor[] m_Sensors;
+    public SensorThread(NoteProximitySensor... sensors) {
+        m_Sensors = sensors;
+    }
+
+    public void run(){
+        try {
+            while(true) {
+                for (NoteProximitySensor sensor : m_Sensors) {
+                    sensor.update();
+                }
+                sleep(1);
+            }
+        } catch (IllegalArgumentException ex) {
+            System.out.println("Got unexpected exception in Note sensor thread. Exiting thread, sensor will no longer be updated");
+        } catch (InterruptedException ex) {
+            System.out.println("Note Sensor Thread was interrupted. Exiting thread, sensor will no longer be updated");
+        }
+    }
+}


### PR DESCRIPTION
This MR reworks the sensor code architecture
- All sensors are now owned by the SensorMonitor subsystem
- The subsystem spawns a single thread that updates all sensors on a 1ms loop
- The thread can be disabled, in which case the sensors are updated from the SensorMonitor periodic
- The SensorMonitor will now try to correct invalid sensor states when detected

Other changes:
- Updates GroundIntake command to run until barrel sensor "sees" note
- Remaps operator controls
- Changes BP source intake angle to new one found tonight
